### PR TITLE
fix: correct sdist build during publish

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip wheel
-          python -m pip install --editable --no-build-isolation .[dev]
+          python -m pip install --editable .[dev]
       - name: Lint with black and ruff
         run: |
           black --check .


### PR DESCRIPTION
Adds a separate "lint" workflow step that also makes the sdist tarball