### PR TITLE
fix: match cython types to C ones

### DIFF
--- a/cryosparc/dataset.pxd
+++ b/cryosparc/dataset.pxd
@@ -1,4 +1,5 @@
-ctypedef Py_ssize_t Dset
+from libc.stdint cimport uint64_t, uint32_t
+ctypedef uint64_t Dset
 
 cdef extern from "cryosparc-tools/dataset.h":
 
@@ -7,18 +8,18 @@ cdef extern from "cryosparc-tools/dataset.h":
     Dset dset_innerjoin(const char *key, Dset dset_r, Dset dset_s) nogil
     void dset_del(Dset dset) nogil
 
-    Py_ssize_t dset_totalsz(Dset dset) nogil
-    long dset_ncol(Dset dset) nogil
-    Py_ssize_t dset_nrow(Dset dset) nogil
-    const char *dset_key(Dset dset, Py_ssize_t index) nogil
+    uint64_t dset_totalsz(Dset dset) nogil
+    uint32_t dset_ncol(Dset dset) nogil
+    uint64_t dset_nrow(Dset dset) nogil
+    const char *dset_key(Dset dset, uint64_t index) nogil
     int dset_type(Dset dset, const char *colkey) nogil
     void *dset_get(Dset dset, const char *colkey) nogil
-    Py_ssize_t dset_getsz(Dset dset, const char *colkey) nogil
-    bint dset_setstr(Dset dset, const char *colkey, Py_ssize_t index, const char *value) nogil
-    const char *dset_getstr(Dset dset, const char *colkey, Py_ssize_t index) nogil
-    long dset_getshp(Dset dset, const char *colkey) nogil
+    uint64_t dset_getsz(Dset dset, const char *colkey) nogil
+    bint dset_setstr(Dset dset, const char *colkey, uint64_t index, const char *value) nogil
+    const char *dset_getstr(Dset dset, const char *colkey, uint64_t index) nogil
+    uint32_t dset_getshp(Dset dset, const char *colkey) nogil
 
-    bint dset_addrows(Dset dset, long num) nogil
+    bint dset_addrows(Dset dset, uint32_t num) nogil
     bint dset_addcol_scalar(Dset dset, const char *key, int type) nogil
     bint dset_addcol_array(Dset dset, const char *key, int type, int shape0, int shape1, int shape2) nogil
     bint dset_changecol(Dset dset, const char *key, int type) nogil

--- a/cryosparc/dtype.py
+++ b/cryosparc/dtype.py
@@ -62,7 +62,7 @@ DSET_TO_TYPE_MAP: Dict[DsetType, Type] = {
     DsetType.T_U32: n.uint32,
     DsetType.T_STR: n.uint64,  # Note: Prefer T_OBJ when working in Python
     DsetType.T_U64: n.uint64,
-    DsetType.T_OBJ: n.object0,
+    DsetType.T_OBJ: n.object_,
 }
 
 TYPE_TO_DSET_MAP = {


### PR DESCRIPTION
In dataset.pxd

Currently dataset type is Py_ssize which is signed and of variable size, whereas dataset.h uses uint64_t. This may be leading to some alignment issues.
