### PR TITLE
fix: correct MASK_IDX bitshift in C dataset

### DIFF
--- a/cryosparc/include/cryosparc-tools/dataset.h
+++ b/cryosparc/include/cryosparc-tools/dataset.h
@@ -363,7 +363,7 @@ moreslots (void) {
 }
 
 #define SHIFT_GEN (64-15)
-#define MASK_IDX  (0xffffffffffffffff >> SHIFT_GEN)
+#define MASK_IDX  (0xffffffffffffffff >> 15)
 
 static inline uint64_t
 roundup(uint64_t value, uint64_t to)

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -265,3 +265,13 @@ def test_append_many_empty():
 
 def test_union_many_empty():
     assert len(Dataset.union_many().rows()) == 0
+
+
+def test_allocate_many():
+    # Checks for logic issues when allocating a lot of datasets
+    for _ in range(3):
+        allocated = []
+        for _ in range(33_000):
+            allocated.append(Dataset(1))
+        assert len(allocated) == 33_000
+        del allocated


### PR DESCRIPTION
Without this we are limited to ~32k datasets in memory. Includes test to catch similar issues