### PR TITLE
Release v4.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v4.1.1
+
+- Use correct numpy object type for newer versions of Numpy
+- Fix limit on number of active datasets
+- Use correct C types in Cython header definition
+
 ## v4.1.0
 
 - Initial release

--- a/cryosparc/__init__.py
+++ b/cryosparc/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "4.1.0"
+__version__ = "4.1.1"
 
 
 def get_include():

--- a/cryosparc/dataset.pxd
+++ b/cryosparc/dataset.pxd
@@ -1,4 +1,5 @@
-ctypedef Py_ssize_t Dset
+from libc.stdint cimport uint64_t, uint32_t
+ctypedef uint64_t Dset
 
 cdef extern from "cryosparc-tools/dataset.h":
 
@@ -7,18 +8,18 @@ cdef extern from "cryosparc-tools/dataset.h":
     Dset dset_innerjoin(const char *key, Dset dset_r, Dset dset_s) nogil
     void dset_del(Dset dset) nogil
 
-    Py_ssize_t dset_totalsz(Dset dset) nogil
-    long dset_ncol(Dset dset) nogil
-    Py_ssize_t dset_nrow(Dset dset) nogil
-    const char *dset_key(Dset dset, Py_ssize_t index) nogil
+    uint64_t dset_totalsz(Dset dset) nogil
+    uint32_t dset_ncol(Dset dset) nogil
+    uint64_t dset_nrow(Dset dset) nogil
+    const char *dset_key(Dset dset, uint64_t index) nogil
     int dset_type(Dset dset, const char *colkey) nogil
     void *dset_get(Dset dset, const char *colkey) nogil
-    Py_ssize_t dset_getsz(Dset dset, const char *colkey) nogil
-    bint dset_setstr(Dset dset, const char *colkey, Py_ssize_t index, const char *value) nogil
-    const char *dset_getstr(Dset dset, const char *colkey, Py_ssize_t index) nogil
-    long dset_getshp(Dset dset, const char *colkey) nogil
+    uint64_t dset_getsz(Dset dset, const char *colkey) nogil
+    bint dset_setstr(Dset dset, const char *colkey, uint64_t index, const char *value) nogil
+    const char *dset_getstr(Dset dset, const char *colkey, uint64_t index) nogil
+    uint32_t dset_getshp(Dset dset, const char *colkey) nogil
 
-    bint dset_addrows(Dset dset, long num) nogil
+    bint dset_addrows(Dset dset, uint32_t num) nogil
     bint dset_addcol_scalar(Dset dset, const char *key, int type) nogil
     bint dset_addcol_array(Dset dset, const char *key, int type, int shape0, int shape1, int shape2) nogil
     bint dset_changecol(Dset dset, const char *key, int type) nogil

--- a/cryosparc/dtype.py
+++ b/cryosparc/dtype.py
@@ -62,7 +62,7 @@ DSET_TO_TYPE_MAP: Dict[DsetType, Type] = {
     DsetType.T_U32: n.uint32,
     DsetType.T_STR: n.uint64,  # Note: Prefer T_OBJ when working in Python
     DsetType.T_U64: n.uint64,
-    DsetType.T_OBJ: n.object0,
+    DsetType.T_OBJ: n.object_,
 }
 
 TYPE_TO_DSET_MAP = {

--- a/cryosparc/include/cryosparc-tools/dataset.h
+++ b/cryosparc/include/cryosparc-tools/dataset.h
@@ -363,7 +363,7 @@ moreslots (void) {
 }
 
 #define SHIFT_GEN (64-15)
-#define MASK_IDX  (0xffffffffffffffff >> SHIFT_GEN)
+#define MASK_IDX  (0xffffffffffffffff >> 15)
 
 static inline uint64_t
 roundup(uint64_t value, uint64_t to)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cryosparc-tools"
-version = "4.1.0"
+version = "4.1.1"
 description = "Toolkit for interfacing with CryoSPARC"
 readme = "README.md"
 requires-python = ">=3.7"

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ elif DEBUG:
 
 setup(
     name="cryosparc_tools",
-    version="4.1.0",
+    version="4.1.1",
     description="Toolkit for interfacing with CryoSPARC",
     headers=["cryosparc/include/cryosparc-tools/dataset.h"],
     ext_modules=cythonize(

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -265,3 +265,13 @@ def test_append_many_empty():
 
 def test_union_many_empty():
     assert len(Dataset.union_many().rows()) == 0
+
+
+def test_allocate_many():
+    # Checks for logic issues when allocating a lot of datasets
+    for _ in range(3):
+        allocated = []
+        for _ in range(33_000):
+            allocated.append(Dataset(1))
+        assert len(allocated) == 33_000
+        del allocated


### PR DESCRIPTION
- match cython types to C ones
- use correct numpy object type
- correct MASK_IDX bitshift in C dataset (fixes limit on number of active datasets)