### PR TITLE
feat: Add support for command_rtp

### DIFF
--- a/cryosparc/command.py
+++ b/cryosparc/command.py
@@ -13,7 +13,7 @@ from urllib.parse import urlencode
 
 class CommandClient:
     """
-    Class for communicating with CryoSPARC's ``command_core``, 
+    Class for communicating with CryoSPARC's ``command_core``,
     ``command_vis`` and ``command_rtp`` HTTP services.
 
     Upon initialization, gets a list of available JSONRPC_ endpoints and creates

--- a/cryosparc/command.py
+++ b/cryosparc/command.py
@@ -13,8 +13,8 @@ from urllib.parse import urlencode
 
 class CommandClient:
     """
-    Class for communicating with CryoSPARC's ``command_core`` and
-    ``command_vis`` HTTP services.
+    Class for communicating with CryoSPARC's ``command_core``, 
+    ``command_vis`` and ``command_rtp`` HTTP services.
 
     Upon initialization, gets a list of available JSONRPC_ endpoints and creates
     corresponding instance methods for each one. Reference of available methods

--- a/cryosparc/tools.py
+++ b/cryosparc/tools.py
@@ -175,7 +175,7 @@ class CryoSPARC:
             else:
                 print(f"Connection FAILED to CryoSPARC command_vis at {self.vis._url}")
                 return False
-        
+
         with make_request(self.rtp, method="get") as response:
             if response.read():
                 print(f"Connection succeeded to CryoSPARC command_rtp at {self.rtp._url}")

--- a/cryosparc/tools.py
+++ b/cryosparc/tools.py
@@ -71,8 +71,8 @@ class CryoSPARC:
     High-level session class for interfacing with a CryoSPARC instance.
 
     Initialize with the host and base port of the running CryoSPARC instance.
-    This host and (at minimum) ``base_port + 2`` and ``base_port + 3`` should be
-    accessible on the network.
+    This host and (at minimum) ``base_port + 2``, ``base_port + 3`` and
+    ``base_port + 5`` should be accessible on the network.
 
     Args:
         license (str, optional): CryoSPARC license key. Defaults to
@@ -91,6 +91,7 @@ class CryoSPARC:
     Attributes:
         cli (CommandClient): HTTP/JSONRPC client for ``command_core`` service (port + 2).
         vis (CommandClient): HTTP/JSONRPC client for ``command_vis`` service (port + 3).
+        rtp (CommandClient): HTTP/JSONRPC client for ``command_rtp`` service (port + 5).
         user_id (str): Mongo object ID of user account performing operations for this session.
 
     Examples:
@@ -125,6 +126,7 @@ class CryoSPARC:
 
     cli: CommandClient
     vis: CommandClient
+    rtp: CommandClient
     user_id: str  # session user ID
 
     def __init__(
@@ -145,6 +147,9 @@ class CryoSPARC:
         )
         self.vis = CommandClient(
             service="command_vis", host=host, port=base_port + 3, headers={"License-ID": license}, timeout=timeout
+        )
+        self.rtp = CommandClient(
+            service="command_rtp", host=host, port=base_port + 5, headers={"License-ID": license}, timeout=timeout
         )
         try:
             self.user_id = self.cli.get_id_by_email_password(email, password)  # type: ignore
@@ -169,6 +174,13 @@ class CryoSPARC:
                 print(f"Connection succeeded to CryoSPARC command_vis at {self.vis._url}")
             else:
                 print(f"Connection FAILED to CryoSPARC command_vis at {self.vis._url}")
+                return False
+        
+        with make_request(self.rtp, method="get") as response:
+            if response.read():
+                print(f"Connection succeeded to CryoSPARC command_rtp at {self.rtp._url}")
+            else:
+                print(f"Connection FAILED to CryoSPARC command_rtp at {self.rtp._url}")
                 return False
 
         return True


### PR DESCRIPTION
I think it would be usefull to also be able to use command_rtp. Although a proper reference is missing, functions can be looked up from cryosparc_command/command_rtp/__init__.py. Maybe a test_connection could be added to command_rtp in next cryosparc release.