### PR TITLE
fix: generation counter overflow on dataset slot

### DIFF
--- a/cryosparc/include/cryosparc-tools/dataset.h
+++ b/cryosparc/include/cryosparc-tools/dataset.h
@@ -362,8 +362,9 @@ moreslots (void) {
 	}
 }
 
-#define SHIFT_GEN (64-15)
-#define MASK_IDX  (0xffffffffffffffff >> 15)
+#define SHIFT_GEN (64-16)
+#define MASK_IDX  (0xffffffffffffffff >> 16)
+#define MAX_GEN   UINT16_MAX
 
 static inline uint64_t
 roundup(uint64_t value, uint64_t to)
@@ -405,6 +406,10 @@ dset_new_(size_t newsize, ds **allocation)
 	unlock();
 
 	memset(s->memory, 0, newsize);
+	if (s->generation >= MAX_GEN) {
+		// Generation limit reached, trigger overflow so that handle != 0
+		s->generation = 0;
+	}
 	gen = ++s->generation;
 
 	return i | (gen << SHIFT_GEN);

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -267,11 +267,20 @@ def test_union_many_empty():
     assert len(Dataset.union_many().rows()) == 0
 
 
-def test_allocate_many():
+def test_allocate_many_separate():
+    for _ in range(66_000):
+        allocated = []
+        for _ in range(3):
+            allocated.append(Dataset(1))
+        assert len(allocated) == 3
+        del allocated
+
+
+def test_allocate_many_together():
     # Checks for logic issues when allocating a lot of datasets
     for _ in range(3):
         allocated = []
-        for _ in range(33_000):
+        for _ in range(66_000):
             allocated.append(Dataset(1))
-        assert len(allocated) == 33_000
+        assert len(allocated) == 66_000
         del allocated


### PR DESCRIPTION
Happens then the same dataset memory slot gets filled up and deallocated many times