### PR TITLE
Fix: extend CommandClient.Error from Exception instead of BaseException

### DIFF
--- a/cryosparc/command.py
+++ b/cryosparc/command.py
@@ -68,7 +68,7 @@ class CommandClient:
 
     service: str
 
-    class Error(BaseException):
+    class Error(Exception):
         def __init__(self, parent: "CommandClient", reason: str, *args: object, url: str = "") -> None:
             msg = f"*** {type(parent).__name__}: ({url}) {reason}"
             super().__init__(msg, *args)


### PR DESCRIPTION
Otherwise errors thrown when connection to command servers are lost dont get caught by `except Exception`