### PR TITLE
Fix: prevent dellocated memory access

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,4 @@ ipython_config.py
 .vercel
 cryosparc/core.c
 *.dSYM
+cython_debug

--- a/cryosparc/dataset.pxd
+++ b/cryosparc/dataset.pxd
@@ -31,4 +31,4 @@ cdef extern from "cryosparc-tools/dataset.h":
     uint64_t dset_strheapsz(Dset dset) nogil
     char *dset_strheap(Dset dset) nogil
     bint dset_setstrheap(Dset dset, const char *heap, size_t size) nogil
-    bint dset_stralloc(Dset dset, const char *value, size_t length, uint64_t *index) nogil
+    int dset_stralloc(Dset dset, const char *value, size_t length, uint64_t *index) nogil

--- a/cryosparc/dataset.py
+++ b/cryosparc/dataset.py
@@ -667,6 +667,7 @@ class Dataset(Streamable, MutableMapping[str, Column], Generic[R]):
         yield header
 
         for f in self:
+            print(f)
             fielddata: "MemoryView"
             if f in compressed_fields:
                 # obj columns added to strheap and loaded as indexes

--- a/cryosparc/dataset.py
+++ b/cryosparc/dataset.py
@@ -667,7 +667,6 @@ class Dataset(Streamable, MutableMapping[str, Column], Generic[R]):
         yield header
 
         for f in self:
-            print(f)
             fielddata: "MemoryView"
             if f in compressed_fields:
                 # obj columns added to strheap and loaded as indexes

--- a/cryosparc/include/cryosparc-tools/dataset.h
+++ b/cryosparc/include/cryosparc-tools/dataset.h
@@ -1741,12 +1741,17 @@ int dset_setstrheap(uint64_t dset, const char *heap, size_t size) {
 }
 
 // Raw string allocation for the dataset without assigning to any column
-// Returns 1 if given index was successfully assigned a value. Should not
-// normally be used.
+// Returns 0 if the string couldn't be allocated
+// Returns 1 if given index was successfully assigned a value.
+// Returns 2 if the index was assigned AND a reallocation occured
+// Should not normally be used.
 int dset_stralloc(uint64_t dset, const char *value, size_t length, uint64_t *index) {
 	uint64_t dsetidx;
 	ds *d = handle_lookup(dset, "dset_stralloc", 0, &dsetidx);
-	return stralloc(dsetidx, value, length, index) != 0;
+	ds *newd = stralloc(dsetidx, value, length, index);
+	if (newd == 0) return 0;
+	else if (newd == d) return 1;
+	else return 2;
 }
 
 #endif


### PR DESCRIPTION
During stream compression. Retrieve column data again when the underlying dataset gets moved due to string allocation.