### PR TITLE
Feat: retry command requests when URLError is raised

### DIFF
--- a/cryosparc/command.py
+++ b/cryosparc/command.py
@@ -4,12 +4,17 @@ servers. Generally should not be used directly.
 """
 from contextlib import contextmanager
 import json
+import os
 import socket
+import time
 import uuid
 from typing import Optional, Type
 from urllib.request import urlopen, Request
 from urllib.error import HTTPError, URLError
 from urllib.parse import urlencode
+from warnings import warn
+
+RETRY_INTERVAL = int(os.getenv("CRYOSPARC_COMMAND_RETRY_SECONDS", 30))
 
 
 class CommandClient:
@@ -102,7 +107,7 @@ class CommandClient:
             }
             res = None
             try:
-                with make_json_request(self, "/api", data=data) as request:
+                with make_json_request(self, "/api", data=data, _stacklevel=4) as request:
                     res = json.loads(request.read())
             except CommandClient.Error as err:
                 raise CommandClient.Error(
@@ -127,7 +132,14 @@ class CommandClient:
 
 @contextmanager
 def make_request(
-    client: CommandClient, method: str = "POST", url: str = "", query: dict = {}, data=None, headers: dict = {}
+    client: CommandClient,
+    method: str = "POST",
+    url: str = "",
+    *,
+    query: dict = {},
+    data=None,
+    headers: dict = {},
+    _stacklevel=2,  # controls warning line number
 ):
     """
     Create a raw HTTP request/response context with the given command client.
@@ -166,15 +178,25 @@ def make_request(
             with urlopen(request, timeout=client._timeout) as response:
                 yield response
                 return
-        except (TimeoutError, socket.timeout):
+        except (TimeoutError, socket.timeout):  # slow network connection request
             error_reason = "Timeout Error"
-            print(
+            warn(
                 f"*** {type(client).__name__}: command ({url}) "
                 f"did not reply within timeout of {client._timeout} seconds, "
-                f"attempt {attempt} of {max_attempts}"
+                f"attempt {attempt} of {max_attempts}",
+                stacklevel=_stacklevel,
             )
             attempt += 1
-        except HTTPError as error:
+        except URLError as error:  # command server may be down
+            error_reason = f"URL Error {error.reason}"
+            warn(
+                f"*** {type(client).__name__}: ({url}) {error_reason}, attempt {attempt} of {max_attempts}. "
+                f"Retrying in {RETRY_INTERVAL} seconds",
+                stacklevel=_stacklevel,
+            )
+            time.sleep(RETRY_INTERVAL)
+            attempt += 1
+        except HTTPError as error:  # command server reported an error
             error_reason = (
                 f"HTTP Error {error.code} {error.reason}; "
                 f"please check cryosparcm log {client.service} for additional information."
@@ -182,17 +204,13 @@ def make_request(
             if error.readable():
                 error_reason += "\nResponse from server: " + str(error.read())
 
-            print(f"*** {type(client).__name__}: ({url}) {error_reason}")
-            break
-        except URLError as error:
-            error_reason = f"URL Error {error.reason}"
-            print(f"*** {type(client).__name__}: ({url}) {error_reason}")
+            warn(f"*** {type(client).__name__}: ({url}) {error_reason}", stacklevel=_stacklevel)
             break
 
     raise CommandClient.Error(client, error_reason, url=url)
 
 
-def make_json_request(client: CommandClient, url="", query={}, data=None, headers={}):
+def make_json_request(client: CommandClient, url="", *, query={}, data=None, headers={}, _stacklevel=3):
     """
     Similar to ``make_request``, except sends request body data JSON and
     receives arbitrary response.
@@ -218,7 +236,7 @@ def make_json_request(client: CommandClient, url="", query={}, data=None, header
     """
     headers = {"Content-Type": "application/json", **headers}
     data = json.dumps(data, cls=client._cls).encode()
-    return make_request(client, url=url, query=query, data=data, headers=headers)
+    return make_request(client, url=url, query=query, data=data, headers=headers, _stacklevel=_stacklevel)
 
 
 def format_server_error(error):


### PR DESCRIPTION
URLError is raised when the command client can't connect to the command server. This may happen during server restarts or temporary losses in connection. With this change, if the connection is restored within 1 minute (by default), the request succeeds. Otherwise, it raises an error like before.

Example output (with shortened retry interval):

```py
❯ CRYOSPARC_COMMAND_RETRY_SECONDS=5 python
Python 3.8.17 | packaged by conda-forge | (default, Jun 16 2023, 07:06:00) 
[GCC 11.4.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from cryosparc.command import CommandClient
>>> cli = CommandClient(port=61102)
>>> # command server goes down
>>> cli.show_scheduler_targets()
<stdin>:1: UserWarning: *** CommandClient: (http://localhost:61102/api) URL Error [Errno 111] Connection refused, attempt 1 of 3. Retrying in 5 seconds
<stdin>:1: UserWarning: *** CommandClient: (http://localhost:61102/api) URL Error [Errno 111] Connection refused, attempt 2 of 3. Retrying in 5 seconds
Traceback (most recent call last):
  File "/u/nfrasser/ecl/cryosparc_package/cryosparc_master/cryosparc_tools/cryosparc/command.py", line 110, in func
    with make_json_request(self, "/api", data=data, _stacklevel=4) as request:
  File "/u/nfrasser/ecl/cryosparc_package/cryosparc_master/deps/anaconda/envs/cryosparc_master_env/lib/python3.8/contextlib.py", line 113, in __enter__
    return next(self.gen)
  File "/u/nfrasser/ecl/cryosparc_package/cryosparc_master/cryosparc_tools/cryosparc/command.py", line 210, in make_request
    raise CommandClient.Error(client, error_reason, url=url)
cryosparc.command.Error: *** CommandClient: (http://localhost:61102/api) URL Error [Errno 111] Connection refused

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/u/nfrasser/ecl/cryosparc_package/cryosparc_master/cryosparc_tools/cryosparc/command.py", line 113, in func
    raise CommandClient.Error(
cryosparc.command.Error: *** CommandClient: (http://localhost:61102) Did not receive a JSON response from method "show_scheduler_targets" with params ()
>>> 