### PR TITLE
Fix(Dataset): Include `stddef.h` in forward declaration section

### DIFF
--- a/cryosparc/include/cryosparc-tools/dataset.h
+++ b/cryosparc/include/cryosparc-tools/dataset.h
@@ -4,6 +4,7 @@
 #include <complex.h>   // complex number support
 #include <stdint.h>    // fixed width integer types
 #include <inttypes.h>  // printf specifiers for fixed width integer types
+#include <stddef.h>    // standard variable types and macros
 
 #define repr(x,a,b,val) val
 


### PR DESCRIPTION
- this fixes a bug when including `dataset.h` in another file, where the compiler throws errors like:
  ```
  cryosparc_tools/cryosparc/include/cryosparc-tools/dataset.h:64:98: error: unknown type name 'size_t'
   64 | int         dset_setstr (uint64_t dset, const char * colkey, uint64_t index, const char * value, size_t length);
  ```