### PR TITLE
CI: Python 3.11 and 3.12 package builds

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -56,9 +56,7 @@ jobs:
       fail-fast: true
       matrix:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
-        # os: ["ubuntu-latest"]
-        python-version: ["3.7", "3.10"]
-        # python-version: ["3.7"]
+        python-version: ["3.7", "3.12"]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -96,6 +96,7 @@ jobs:
       - uses: pypa/cibuildwheel@v2.16.2
         env:
           CIBW_SKIP: cp36-* pp*-win* pp*-macosx* *_i686
+          CIBW_ARCHS_LINUX: "x86_64 aarch64"
           CIBW_ARCHS_MACOS: "x86_64 arm64 universal2"
           CIBW_ARCHS_WINDOWS: "AMD64 ARM64"
         with:

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -93,6 +93,11 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
+      - name: Set up QEMU
+        if: runner.os == 'Linux'
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm64
       - uses: pypa/cibuildwheel@v2.16.2
         env:
           CIBW_SKIP: cp36-* pp*-win* pp*-macosx* *_i686

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -85,7 +85,7 @@ jobs:
 
   build:
     needs: [test]
-    if: "startsWith(github.ref, 'refs/tags/')"
+    # if: "startsWith(github.ref, 'refs/tags/')"
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: true
@@ -95,10 +95,10 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
-      - uses: pypa/cibuildwheel@v2.11.2
+      - uses: pypa/cibuildwheel@v2.16.2
         env:
-          CIBW_SKIP: cp36-* pp*-win* pp*-macosx* *_i686 cp3{8,9,10,11}-macosx_x86_64
-          CIBW_ARCHS_MACOS: "x86_64 universal2"
+          CIBW_SKIP: cp36-* pp*-win* pp*-macosx* *_i686
+          CIBW_ARCHS_MACOS: "x86_64 arm64 universal2"
           CIBW_ARCHS_WINDOWS: "AMD64 ARM64"
         with:
           output-dir: dist

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -83,7 +83,7 @@ jobs:
 
   build:
     needs: [test]
-    # if: "startsWith(github.ref, 'refs/tags/')"
+    if: "startsWith(github.ref, 'refs/tags/')"
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: true


### PR DESCRIPTION
- Updated to the latest `pypa/cibuildwheel` action
- Ensure dedicated x64 and ARM builds for macOS
- ARM builds for Linux