### PR TITLE
Docs: show warning when connecting to incompatible CryoSPARC

### DIFF
--- a/cryosparc/__init__.py
+++ b/cryosparc/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "4.3.1"
+__version__ = "4.4.0"
 
 
 def get_include():

--- a/cryosparc/tools.py
+++ b/cryosparc/tools.py
@@ -56,7 +56,7 @@ LICENSE_REGEX = re.compile(r"[a-f\d]{8}-[a-f\d]{4}-[a-f\d]{4}-[a-f\d]{4}-[a-f\d]
 """Regular expression for matching CryoSPARC license IDs."""
 
 VERSION_REGEX = re.compile(r"^v\d+\.\d+\.\d+")
-"""Regular version for CryoSPARC minor version, e.g., 'v4.1.0'"""
+"""Regular expression for CryoSPARC minor version, e.g., 'v4.1.0'"""
 
 SUPPORTED_EXPOSURE_FORMATS = {
     "MRC",
@@ -185,7 +185,7 @@ class CryoSPARC:
                     "To install a compatible version of cryosparc-tools:\n\n"
                     f"    pip install --force cryosparc-tools~={minor_cs_version}.0\n\n"
                     "Or, if running a CryoSPARC pre-release or private beta:\n\n"
-                    f"    pip install --force {tools_prerelease_url}\n",
+                    f"    pip install --no-cache --force {tools_prerelease_url}\n",
                     stacklevel=2,
                 )
 

--- a/cryosparc/tools.py
+++ b/cryosparc/tools.py
@@ -174,13 +174,13 @@ class CryoSPARC:
         except Exception as e:
             raise RuntimeError("Could not complete CryoSPARC authentication with given credentials") from e
 
-        if cs_version and cs_version != "develop" and VERSION_REGEX.match(cs_version):
+        if cs_version and VERSION_REGEX.match(cs_version):
             minor_cs_version = ".".join(cs_version[1:].split(".")[:2])  # e.g., v4.1.0 -> 4.1
             minor_tools_version = ".".join(__version__.split(".")[:2])  # e.g., 4.1.0 -> 4.1
             tools_prerelease_url = "https://github.com/cryoem-uoft/cryosparc-tools/archive/refs/heads/develop.zip"
             if minor_cs_version != minor_tools_version:
                 warn(
-                    f"CryoSPARC version {cs_version} for instance {host}:{base_port} "
+                    f"CryoSPARC instance {host}:{base_port} with version {cs_version} "
                     f"may not be compatible with current cryosparc-tools version v{__version__}.\n\n"
                     "To install a compatible version of cryosparc-tools:\n\n"
                     f"    pip install --force cryosparc-tools~={minor_cs_version}.0\n\n"

--- a/cryosparc/tools.py
+++ b/cryosparc/tools.py
@@ -175,15 +175,15 @@ class CryoSPARC:
             raise RuntimeError("Could not complete CryoSPARC authentication with given credentials") from e
 
         if cs_version and VERSION_REGEX.match(cs_version):
-            minor_cs_version = ".".join(cs_version[1:].split(".")[:2])  # e.g., v4.1.0 -> 4.1
-            minor_tools_version = ".".join(__version__.split(".")[:2])  # e.g., 4.1.0 -> 4.1
+            cs_major_minor_version = ".".join(cs_version[1:].split(".")[:2])  # e.g., v4.1.0 -> 4.1
+            tools_major_minor_version = ".".join(__version__.split(".")[:2])  # e.g., 4.1.0 -> 4.1
             tools_prerelease_url = "https://github.com/cryoem-uoft/cryosparc-tools/archive/refs/heads/develop.zip"
-            if minor_cs_version != minor_tools_version:
+            if cs_major_minor_version != tools_major_minor_version:
                 warn(
                     f"CryoSPARC instance {host}:{base_port} with version {cs_version} "
                     f"may not be compatible with current cryosparc-tools version v{__version__}.\n\n"
                     "To install a compatible version of cryosparc-tools:\n\n"
-                    f"    pip install --force cryosparc-tools~={minor_cs_version}.0\n\n"
+                    f"    pip install --force cryosparc-tools~={cs_major_minor_version}.0\n\n"
                     "Or, if running a CryoSPARC pre-release or private beta:\n\n"
                     f"    pip install --no-cache --force {tools_prerelease_url}\n",
                     stacklevel=2,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cryosparc-tools"
-version = "4.3.1"
+version = "4.4.0"
 description = "Toolkit for interfacing with CryoSPARC"
 readme = "README.md"
 requires-python = ">=3.7"

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ elif DEBUG:
 
 setup(
     name="cryosparc_tools",
-    version="4.3.1",
+    version="4.4.0",
     description="Toolkit for interfacing with CryoSPARC",
     headers=["cryosparc/include/cryosparc-tools/dataset.h"],
     ext_modules=cythonize(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -103,6 +103,7 @@ def request_callback_core(request, uri, response_headers):
     body = json.loads(request.body)
     procs = {
         "hello_world": {"hello": "world"},
+        "get_running_version": "develop",
         "get_id_by_email_password": "6372a35e821ed2b71d9fe4e3",
         "get_job": {
             "uid": "J1",


### PR DESCRIPTION
Example output:
```
In [1]: from cryosparc.tools import CryoSPARC

In [2]: cs = CryoSPARC(base_port=62000)
<ipython-input-2-3c3de64e7601>:1: UserWarning: CryoSPARC instance localhost:62000 with version v4.4.0 may not be compatible with current cryosparc-tools version v4.3.1.

To install a compatible version of cryosparc-tools:

    pip install --force cryosparc-tools~=4.4.0

Or, if running a CryoSPARC pre-release or private beta:

    pip install --force https://github.com/cryoem-uoft/cryosparc-tools/archive/refs/heads/develop.zip

  cs = CryoSPARC(base_port=62000)

In [3]:
```