### PR TITLE
Chore: Remove unused "starting" job status

### DIFF
--- a/cryosparc/job.py
+++ b/cryosparc/job.py
@@ -177,7 +177,6 @@ class Job(MongoController[JobDocument]):
         - 'building'
         - 'queued'
         - 'launched'
-        - 'started'
         - 'running'
         - 'waiting'
         - 'completed'

--- a/cryosparc/spec.py
+++ b/cryosparc/spec.py
@@ -46,7 +46,6 @@ JobStatus = Literal[
     "building",
     "queued",
     "launched",
-    "started",
     "running",
     "waiting",
     "completed",


### PR DESCRIPTION
- May not be used in upcoming CryoSPARC release.