### PR TITLE
Project.dir and Job.dir should be properties

### DIFF
--- a/cryosparc/job.py
+++ b/cryosparc/job.py
@@ -105,6 +105,7 @@ class Job(MongoController[JobDocument]):
         self._doc = self.cs.cli.get_job(self.project_uid, self.uid)  # type: ignore
         return self
 
+    @property
     def dir(self) -> PurePosixPath:
         """
         Get the path to the job directory.

--- a/cryosparc/project.py
+++ b/cryosparc/project.py
@@ -46,6 +46,7 @@ class Project(MongoController[ProjectDocument]):
         self._doc = self.cs.cli.get_project(self.uid)  # type: ignore
         return self
 
+    @property
     def dir(self) -> PurePosixPath:
         """
         Get the path to the project directory.


### PR DESCRIPTION
May I gently suggest that the directories of `Project`s and `Job`s should be a properties instead (i.e., `Project.dir` instead of `Project.dir()`).

I realize this is a breaking change so feel free to ignore, it's very nitpicky.