### PR TITLE
Fix .dir() documentation examples

### DIFF
--- a/docs/examples/connect_series_to_class3D.ipynb
+++ b/docs/examples/connect_series_to_class3D.ipynb
@@ -61,7 +61,7 @@
     "desired_volume_series = 0\n",
     "\n",
     "series_path = var3Ddisp_job.load_output(f\"series_{desired_volume_series}\")[\"series/path\"][0]\n",
-    "series_path = str(project.dir() / series_path)"
+    "series_path = str(project.dir / series_path)"
    ]
   },
   {

--- a/docs/examples/delete-rejected-exposures.ipynb
+++ b/docs/examples/delete-rejected-exposures.ipynb
@@ -53,7 +53,7 @@
     "from pathlib import Path\n",
     "\n",
     "project = cs.find_project(\"P251\")\n",
-    "project_dir = Path(project.dir())"
+    "project_dir = Path(project.dir)"
    ]
   },
   {


### PR DESCRIPTION
This should have been done as part of b4233bc, I apologize. `job.dir()` will now throw an error, examples should use `job.dir`.