### PR TITLE
Fix: keep fields when appending empty datasets

### DIFF
--- a/cryosparc/dataset.py
+++ b/cryosparc/dataset.py
@@ -69,7 +69,7 @@ from .dtype import (
 from .errors import DatasetLoadError
 from .row import R, Row, Spool
 from .stream import AsyncBinaryIO, Streamable
-from .util import bopen, default_rng, first, hashcache, random_integers, u32bytesle, u32intle
+from .util import bopen, default_rng, hashcache, random_integers, u32bytesle, u32intle
 
 if TYPE_CHECKING:
     from numpy.typing import ArrayLike, DTypeLike, NDArray
@@ -275,7 +275,7 @@ class Dataset(Streamable, MutableMapping[str, Column], Generic[R]):
         if not datasets:
             return cls()
 
-        first_dset = first(datasets)
+        first_dset = datasets[0]
         datasets = tuple(d for d in datasets if len(d) > 0)  # skip empty datasets
         if not datasets:
             return cls(first_dset)  # so that fields are kept

--- a/cryosparc/dataset.py
+++ b/cryosparc/dataset.py
@@ -272,7 +272,6 @@ class Dataset(Streamable, MutableMapping[str, Column], Generic[R]):
         Returns:
             Dataset: Appended dataset
         """
-        datasets = tuple(d for d in datasets if len(d) > 0)  # skip empty datasets
         if not datasets:
             return cls()
 

--- a/cryosparc/dataset.py
+++ b/cryosparc/dataset.py
@@ -69,7 +69,7 @@ from .dtype import (
 from .errors import DatasetLoadError
 from .row import R, Row, Spool
 from .stream import AsyncBinaryIO, Streamable
-from .util import bopen, default_rng, hashcache, random_integers, u32bytesle, u32intle
+from .util import bopen, default_rng, first, hashcache, random_integers, u32bytesle, u32intle
 
 if TYPE_CHECKING:
     from numpy.typing import ArrayLike, DTypeLike, NDArray
@@ -274,6 +274,11 @@ class Dataset(Streamable, MutableMapping[str, Column], Generic[R]):
         """
         if not datasets:
             return cls()
+
+        first_dset = first(datasets)
+        datasets = tuple(d for d in datasets if len(d) > 0)  # skip empty datasets
+        if not datasets:
+            return cls(first_dset)  # so that fields are kept
 
         if not repeat_allowed:
             all_uids = n.concatenate([dset["uid"] for dset in datasets])

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -284,6 +284,14 @@ def test_append_many_empty():
     assert len(Dataset.append_many().rows()) == 0
 
 
+def test_append_empty_fields():
+    d1 = Dataset.allocate(0, [("field", "f4")])
+    d2 = Dataset.allocate(0, [("field", "f4")])
+    d3 = d1.append(d2)
+    assert len(d3) == 0
+    assert d3.fields() == ["uid", "field"]
+
+
 def test_union_many_empty():
     assert len(Dataset.union_many().rows()) == 0
 


### PR DESCRIPTION
Useful when appending on a loop and want to keep fields around