### PR TITLE
Refactor: Dataset interface updates for future improved job I/O

### DIFF
--- a/cryosparc/dataset.py
+++ b/cryosparc/dataset.py
@@ -1060,7 +1060,7 @@ class Dataset(Streamable, MutableMapping[str, Column], Generic[R]):
         test = (lambda n: n in names) if isinstance(names, Collection) else names
         new_fields = [f for f in self.fields() if f == "uid" or test(f)]
         if len(new_fields) == self._data.ncol():
-            return self  # nothing to filter
+            return self.copy() if copy else self  # nothing to filter
 
         result = type(self)([(key, self[key]) for key in new_fields])
         return result if copy else self._reset(result._data)

--- a/cryosparc/dataset.py
+++ b/cryosparc/dataset.py
@@ -861,7 +861,7 @@ class Dataset(Streamable, MutableMapping[str, Column], Generic[R]):
         Check whether two datasets contain the same data in the same order.
 
         Args:
-            other (Dataset): dataset to compare
+            other (object): dataset to compare
 
         Returns:
             bool: True or False
@@ -1507,7 +1507,7 @@ class Dataset(Streamable, MutableMapping[str, Column], Generic[R]):
         order.
 
         Args:
-            other (Dataset): dataset to compare
+            other (object): dataset to compare
 
         Returns:
             bool: True or False

--- a/cryosparc/dataset.py
+++ b/cryosparc/dataset.py
@@ -1095,7 +1095,7 @@ class Dataset(Streamable, MutableMapping[str, Column], Generic[R]):
         """
         return self.filter_fields(lambda n: any(n.startswith(p + "/") for p in prefixes), copy=copy)
 
-    def filter_prefix(self, keep_prefix: str, *, rename: str | None = None, copy: bool = False):
+    def filter_prefix(self, keep_prefix: str, *, rename: Optional[str] = None, copy: bool = False):
         """
         Similar to ``filter_prefixes`` but for a single prefix.
 

--- a/cryosparc/dataset.py
+++ b/cryosparc/dataset.py
@@ -980,6 +980,28 @@ class Dataset(Streamable, MutableMapping[str, Column], Generic[R]):
         """
         return list({f.split("/")[0] for f in self.fields(exclude_uid=True)})
 
+    def prefix_descr(self, prefix: str, new_prefix: str | None = None) -> List[Field]:
+        """
+        Get the dataset fields with the given prefix. Optionally replace the
+        prefix with another one before returning. Does not mutate dataset; use
+        rename_prefix instead.
+
+        Args:
+            prefix (str): Prefix to filter by.
+            new_prefix (str | None, optional): Replace the prefix with this one
+                before returning. Defaults to None.
+
+        Returns:
+            List[Field]: _description_
+        """
+        prefix_fields: List[Field] = [f for f in self.descr() if f[0].startswith(f"{prefix}/")]
+        if new_prefix and prefix != new_prefix:
+            prefix_fields = [
+                (f"{new_prefix}/{f[0].split('/', 1)[1]}", *f[1:])  # type: ignore
+                for f in prefix_fields
+            ]
+        return prefix_fields
+
     @overload
     def add_fields(self, fields: List[Field]) -> "Dataset[R]": ...
     @overload

--- a/cryosparc/dataset.py
+++ b/cryosparc/dataset.py
@@ -1495,7 +1495,25 @@ class Dataset(Streamable, MutableMapping[str, Column], Generic[R]):
 
         return result
 
-    def to_cstrs(self, copy: bool = False):
+    def is_equivalent(self, other: object):
+        """
+        Check whether two datasets contain the same data, regardless of field
+        order.
+
+        Args:
+            other (Dataset): dataset to compare
+
+        Returns:
+            bool: True or False
+        """
+        return (
+            isinstance(other, Dataset)
+            and len(self) == len(other)
+            and set(self.descr()) == set(other.descr())
+            and all(n.array_equal(self[f], other[f]) for f in self)
+        )
+
+    def to_cstrs(self, *, copy: bool = False):
         """
         Convert all Python string columns to C strings. Resulting dataset fields
         that previously had dtype ``np.object_`` (or ``T_OBJ`` internally) will get

--- a/cryosparc/dataset.py
+++ b/cryosparc/dataset.py
@@ -1076,7 +1076,7 @@ class Dataset(Streamable, MutableMapping[str, Column], Generic[R]):
 
         return self._reset()
 
-    def filter_fields(self, names: Union[Collection[str], Callable[[str], bool]], copy: bool = False):
+    def filter_fields(self, names: Union[Collection[str], Callable[[str], bool]], *, copy: bool = False):
         """
         Keep only the given fields from the dataset. Provide a list of fields or
         function that returns ``True`` if a given field name should be kept.
@@ -1152,7 +1152,7 @@ class Dataset(Streamable, MutableMapping[str, Column], Generic[R]):
         result = type(self)([("uid", self["uid"])] + [(nf, self[f]) for f, nf in zip(keep_fields, new_fields)])
         return result if copy else self._reset(result._data)
 
-    def drop_fields(self, names: Union[Collection[str], Callable[[str], bool]], copy: bool = False):
+    def drop_fields(self, names: Union[Collection[str], Callable[[str], bool]], *, copy: bool = False):
         """
         Remove the given field names from the dataset. Provide a list of fields
         or a function that takes a field name and returns True if that field
@@ -1171,7 +1171,7 @@ class Dataset(Streamable, MutableMapping[str, Column], Generic[R]):
         test = (lambda n: n not in names) if isinstance(names, Collection) else (lambda n: not names(n))  # type: ignore
         return self.filter_fields(test, copy=copy)
 
-    def rename_fields(self, field_map: Union[Dict[str, str], Callable[[str], str]], copy: bool = False):
+    def rename_fields(self, field_map: Union[Dict[str, str], Callable[[str], str]], *, copy: bool = False):
         """
         Change the name of dataset fields based on the given mapping.
 
@@ -1192,7 +1192,7 @@ class Dataset(Streamable, MutableMapping[str, Column], Generic[R]):
         result = type(self)([(f if f == "uid" else fm(f), self[f]) for f in self])
         return result if copy else self._reset(result._data)
 
-    def rename_field(self, current_name: str, new_name: str, copy: bool = False):
+    def rename_field(self, current_name: str, new_name: str, *, copy: bool = False):
         """
         Change name of a dataset field based on the given mapping.
 
@@ -1207,7 +1207,7 @@ class Dataset(Streamable, MutableMapping[str, Column], Generic[R]):
         """
         return self.rename_fields({current_name: new_name}, copy=copy)
 
-    def rename_prefix(self, old_prefix: str, new_prefix: str, copy: bool = False):
+    def rename_prefix(self, old_prefix: str, new_prefix: str, *, copy: bool = False):
         """
         Similar to rename_fields, except changes the prefix of all fields with
         the given ``old_prefix`` to ``new_prefix``.
@@ -1541,7 +1541,7 @@ class Dataset(Streamable, MutableMapping[str, Column], Generic[R]):
         self._reset()  # in case data got reallocated
         return dset
 
-    def to_pystrs(self, copy: bool = False):
+    def to_pystrs(self, *, copy: bool = False):
         """
         Convert all C string columns to Python strings. Resulting dataset fields
         that previously had dtype ``np.uint64`` (and ``T_STR`` internally) will

--- a/cryosparc/dataset.py
+++ b/cryosparc/dataset.py
@@ -24,7 +24,7 @@ Dataset supports:
 
 """
 
-from functools import lru_cache, reduce
+from functools import reduce
 from pathlib import PurePath
 from typing import (
     IO,

--- a/cryosparc/dataset.py
+++ b/cryosparc/dataset.py
@@ -1092,16 +1092,14 @@ class Dataset(Streamable, MutableMapping[str, Column], Generic[R]):
             Dataset: current dataset or copy with filtered fields
         """
         test = (lambda n: n in names) if isinstance(names, Collection) else names
-        new_fields = [f for f in self.descr() if f[0] == "uid" or test(f[0])]
-        if len(new_fields) == len(self.descr()):
-            return self
+        new_fields = [f for f in self.fields() if f == "uid" or test(f)]
+        if len(new_fields) == self._data.ncol():
+            return self  # nothing to filter
 
-        result = self.allocate(len(self), new_fields)
-        for key, *_ in new_fields:
-            result[key] = self[key]
+        result = type(self)([(key, self[key]) for key in new_fields])
         return result if copy else self._reset(result._data)
 
-    def filter_prefixes(self, prefixes: Collection[str], copy: bool = False):
+    def filter_prefixes(self, prefixes: Collection[str], *, copy: bool = False):
         """
         Similar to ``filter_fields``, except takes list of prefixes.
 


### PR DESCRIPTION
- New `rename` param for filter prefix to allow pulling out a renamed subset of fields in one shot
- New `is_equivalent` method to check whether datasets have identical fields that may be out of order
- Require that `copy` param is specified as kwarg
- Removed load_cached method