### PR TITLE
Fix: correct Dataset.descr() implementation

### DIFF
--- a/cryosparc/dataset.py
+++ b/cryosparc/dataset.py
@@ -932,7 +932,8 @@ class Dataset(Streamable, MutableMapping[str, Column], Generic[R]):
         Returns:
             list[Field]: Fields
         """
-        return [get_data_field(self._data, self._data.key(i)) for i in range(self._data.ncol())]
+        descr = [get_data_field(self._data, self._data.key(i)) for i in range(self._data.ncol())]
+        return [f for f in descr if f[0] != "uid"] if exclude_uid else descr
 
     def copy(self):
         """

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -62,6 +62,19 @@ def test_empty_data_constructor():
     assert len(data.descr()) == 1
 
 
+def test_fields():
+    data = Dataset.allocate(3, [("test1", "<u4"), ("test2", "<f8", (2,))])
+    assert data.fields() == ["uid", "test1", "test2"]
+    assert data.fields(exclude_uid=True) == ["test1", "test2"]
+
+
+def test_descr():
+    data = Dataset.allocate(3, [("test1", "<u4"), ("test2", "<f8", (2,))])
+    expected_descr = [("uid", "<u8"), ("test1", "<u4"), ("test2", "<f8", (2,))]
+    assert data.descr() == expected_descr
+    assert data.descr(exclude_uid=True) == expected_descr[1:]
+
+
 def test_invalid_data_fields():
     # This is ok actually
     assert Dataset(


### PR DESCRIPTION
Make sure `exclude_uid` param works. Reported by Harris.