### PR TITLE
CI: Windows and Artifact upload build fixes

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -88,8 +88,8 @@ jobs:
           pytest -v --benchmark-disable -n auto
 
   build:
-    # needs: [test]
-    # if: "startsWith(github.ref, 'refs/tags/')"
+    needs: [test]
+    if: "startsWith(github.ref, 'refs/tags/')"
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: true
@@ -107,6 +107,7 @@ jobs:
       - uses: pypa/cibuildwheel@v2.17.0
         env:
           CIBW_SKIP: cp36-* pp*-win* pp*-macosx* *_i686
+          CIBW_TEST_SKIP: "*-win_arm64"
           CIBW_ARCHS_LINUX: "x86_64 aarch64"
           CIBW_ARCHS_MACOS: "x86_64 arm64 universal2"
           CIBW_ARCHS_WINDOWS: "AMD64 ARM64"

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -114,7 +114,7 @@ jobs:
           output-dir: dist
       - uses: actions/upload-artifact@v4
         with:
-          name: wheels
+          name: wheels-${{ runner.os }}
           path: dist
 
   release:
@@ -126,6 +126,15 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           name: wheels
+      - uses: actions/download-artifact@v4
+        with:
+          name: wheels-Linux
+      - uses: actions/download-artifact@v4
+        with:
+          name: wheels-macOS
+      - uses: actions/download-artifact@v4
+        with:
+          name: wheels-Windows
       - uses: actions/setup-python@v5
         with:
           python-version: "3.10"

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -88,8 +88,8 @@ jobs:
           pytest -v --benchmark-disable -n auto
 
   build:
-    needs: [test]
-    if: "startsWith(github.ref, 'refs/tags/')"
+    # needs: [test]
+    # if: "startsWith(github.ref, 'refs/tags/')"
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: true
@@ -104,7 +104,7 @@ jobs:
         uses: docker/setup-qemu-action@v3
         with:
           platforms: arm64
-      - uses: pypa/cibuildwheel@v2.16.2
+      - uses: pypa/cibuildwheel@v2.17.0
         env:
           CIBW_SKIP: cp36-* pp*-win* pp*-macosx* *_i686
           CIBW_ARCHS_LINUX: "x86_64 aarch64"


### PR DESCRIPTION
- Updated to pypa/cibuildwheel@v2.17.0 to avoid Windows build crash
- Separate artifact uploads to keep names unique due to breaking changes in actions/upload-artifact@v4