### PR TITLE
Numpy 2.0 support 

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,13 +10,13 @@ repos:
       - id: check-yaml
       - id: check-added-large-files
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.4.1
+    rev: v0.4.9
     hooks:
       - id: ruff
         args: [--fix, --select, I, --exit-non-zero-on-fix]
       - id: ruff-format
   - repo: https://github.com/RobertCraigie/pyright-python
-    rev: v1.1.359
+    rev: v1.1.367
     hooks:
       - id: pyright
         additional_dependencies: [cython, httpretty, numpy, pytest]

--- a/cryosparc/column.py
+++ b/cryosparc/column.py
@@ -63,10 +63,10 @@ class Column(n.ndarray):
 
         return obj
 
-    def __array_wrap__(self, obj, context=None):
+    def __array_wrap__(self, obj, context=None, return_scalar=False):
         # This prevents wrapping single results such as aggregations from n.sum
         # or n.median
-        return obj[()] if obj.shape == () else super().__array_wrap__(obj, context)
+        return obj[()] if obj.shape == () else super().__array_wrap__(obj, context, return_scalar)  # type: ignore
 
     def to_fixed(self) -> "Column":
         """

--- a/cryosparc/dataset.py
+++ b/cryosparc/dataset.py
@@ -746,11 +746,11 @@ class Dataset(Streamable, MutableMapping[str, Column], Generic[R]):
                 populate.append((field, allocate[field[0]]))
         elif isinstance(allocate, Mapping):
             for f, v in allocate.items():
-                a = n.array(v, copy=False)
+                a = n.asarray(v)
                 populate.append((safe_makefield(f, arraydtype(a)), a))
         else:
             for f, v in allocate:
-                a = n.array(v, copy=False)
+                a = n.asarray(v)
                 populate.append((safe_makefield(f, arraydtype(a)), a))
 
         # Check that all entries are the same length

--- a/cryosparc/dataset.py
+++ b/cryosparc/dataset.py
@@ -39,6 +39,7 @@ from typing import (
     Mapping,
     MutableMapping,
     Optional,
+    Sequence,
     Set,
     Tuple,
     Type,
@@ -151,7 +152,7 @@ class Dataset(Streamable, MutableMapping[str, Column], Generic[R]):
     _data: Data
 
     @classmethod
-    def allocate(cls, size: int = 0, fields: List[Field] = []):
+    def allocate(cls, size: int = 0, fields: Sequence[Field] = []):
         """
         Allocate a dataset with the given number of rows and specified fields.
 
@@ -977,13 +978,13 @@ class Dataset(Streamable, MutableMapping[str, Column], Generic[R]):
         return list({f.split("/")[0] for f in self.fields(exclude_uid=True)})
 
     @overload
-    def add_fields(self, fields: List[Field]) -> "Dataset[R]": ...
+    def add_fields(self, fields: Sequence[Field]) -> "Dataset[R]": ...
     @overload
-    def add_fields(self, fields: List[str], dtypes: Union[str, List["DTypeLike"]]) -> "Dataset[R]": ...
+    def add_fields(self, fields: Sequence[str], dtypes: Union[str, Sequence["DTypeLike"]]) -> "Dataset[R]": ...
     def add_fields(
         self,
-        fields: Union[List[str], List[Field]],
-        dtypes: Union[str, List["DTypeLike"], Literal[None]] = None,
+        fields: Union[Sequence[str], Sequence[Field]],
+        dtypes: Union[str, Sequence["DTypeLike"], Literal[None]] = None,
     ) -> "Dataset[R]":
         """
         Adds the given fields to the dataset. If a field with the same name

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
     "Topic :: Software Development :: Libraries",
 ]
 license = { file = "LICENSE" }
-dependencies = ["numpy >= 1.15", "typing-extensions >= 3.7"]
+dependencies = ["numpy >= 1.15, < 3.0", "typing-extensions >= 3.7"]
 
 [project.optional-dependencies]
 dev = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
     "Topic :: Software Development :: Libraries",
 ]
 license = { file = "LICENSE" }
-dependencies = ["numpy ~= 1.15", "typing-extensions >= 3.7"]
+dependencies = ["numpy >= 1.15", "typing-extensions >= 3.7"]
 
 [project.optional-dependencies]
 dev = [


### PR DESCRIPTION
- Looser numpy version requirement
- `__array_wrap__` deprecation fix
- Replace `np.array(a, copy=False)` with `np.asarray(a)`