### PR TITLE
Refactor: Dataset load memory optimizations

### DIFF
--- a/cryosparc/column.py
+++ b/cryosparc/column.py
@@ -68,6 +68,15 @@ class Column(n.ndarray):
         # or n.median
         return obj[()] if obj.shape == () else super().__array_wrap__(obj, context, return_scalar)  # type: ignore
 
+    def __setitem__(self, key, value):
+        if isinstance(value, n.ndarray):
+            # parse fixed-size size strings
+            if value.dtype.char == "S":
+                value = n.vectorize(hashcache(bytes.decode), otypes="O")(value)
+            elif value.dtype.char == "U":
+                value = n.vectorize(hashcache(str), otypes="O")(value)
+        return super().__setitem__(key, value)
+
     def to_fixed(self) -> "Column":
         """
         If this Column is composed of Python objects, convert to fixed-size

--- a/cryosparc/dataset.py
+++ b/cryosparc/dataset.py
@@ -628,7 +628,8 @@ class Dataset(Streamable, MutableMapping[str, Column], Generic[R]):
         cstrs: bool = False,
     ):
         # Use mmap to avoid loading full record array into memory
-        mmap_mode = "r" if isinstance(file, (str, PurePath)) else None
+        # cast path to a string for older numpy/python
+        mmap_mode, f = ("r", str(file)) if isinstance(file, (str, PurePath)) else (None, file)
         indata = n.load(file, mmap_mode=mmap_mode, allow_pickle=False)
         size = len(indata)
         descr = filter_descr(indata.dtype.descr, keep_prefixes=prefixes, keep_fields=fields)

--- a/cryosparc/dataset.py
+++ b/cryosparc/dataset.py
@@ -615,7 +615,7 @@ class Dataset(Streamable, MutableMapping[str, Column], Generic[R]):
 
     @classmethod
     def _load_numpy_header(cls, file: Union[str, PurePath]) -> DatasetHeader:
-        indata = n.load(file, mmap_mode="r", allow_pickle=False)
+        indata = n.load(str(file), mmap_mode="r", allow_pickle=False)
         fields = [normalize_field(f[0], fielddtype(f)) for f in indata.dtype.descr]
         return DatasetHeader(length=len(indata), dtype=fields, compression=None, compressed_fields=[])
 

--- a/cryosparc/dataset.py
+++ b/cryosparc/dataset.py
@@ -32,7 +32,6 @@ from typing import (
     Any,
     Callable,
     Collection,
-    Container,
     Dict,
     Generator,
     Generic,
@@ -70,7 +69,7 @@ from .dtype import (
 from .errors import DatasetLoadError
 from .row import R, Row, Spool
 from .stream import AsyncBinaryIO, Streamable
-from .util import bopen, default_rng, hashcache, random_integers, u32bytesle, u32intle
+from .util import bopen, default_rng, random_integers, u32bytesle, u32intle
 
 if TYPE_CHECKING:
     from numpy.typing import ArrayLike, DTypeLike, NDArray

--- a/cryosparc/dataset.py
+++ b/cryosparc/dataset.py
@@ -603,7 +603,11 @@ class Dataset(Streamable, MutableMapping[str, Column], Generic[R]):
                     f.seek(0)  # will be done after context block for mmapping
                 elif prefix == FORMAT_MAGIC_PREFIXES[CSDAT_FORMAT]:
                     return cls._load_stream(
-                        f, prefixes=prefixes, fields=fields, cstrs=cstrs, seekable=isinstance(f, (str, PurePath))
+                        f,
+                        prefixes=prefixes,
+                        fields=fields,
+                        cstrs=cstrs,
+                        seekable=isinstance(file, (str, PurePath)),
                     )
                 else:
                     raise ValueError(f"Could not determine dataset format (prefix is {prefix})")
@@ -688,7 +692,7 @@ class Dataset(Streamable, MutableMapping[str, Column], Generic[R]):
             colsize = u32intle(f.read(4))
             if field[0] not in field_names:
                 # try to seek instead of read to reduce memory usage
-                f.seek(colsize) if seekable else f.read(colsize)
+                f.seek(colsize, 1) if seekable else f.read(colsize)
                 continue  # skip fields that were not selected
             buffer = f.read(colsize)
             if field[0] in header["compressed_fields"]:

--- a/cryosparc/dataset.py
+++ b/cryosparc/dataset.py
@@ -568,8 +568,8 @@ class Dataset(Streamable, MutableMapping[str, Column], Generic[R]):
         cls,
         file: Union[str, PurePath, IO[bytes]],
         *,
-        prefixes: Sequence[str] | None = None,
-        fields: Sequence[str] | None = None,
+        prefixes: Optional[Sequence[str]] = None,
+        fields: Optional[Sequence[str]] = None,
         cstrs: bool = False,
     ):
         """
@@ -623,8 +623,8 @@ class Dataset(Streamable, MutableMapping[str, Column], Generic[R]):
     def _load_numpy(
         cls,
         file: Union[str, PurePath, IO[bytes]],
-        prefixes: Sequence[str] | None = None,
-        fields: Sequence[str] | None = None,
+        prefixes: Optional[Sequence[str]] = None,
+        fields: Optional[Sequence[str]] = None,
         cstrs: bool = False,
     ):
         # Use mmap to avoid loading full record array into memory
@@ -660,8 +660,8 @@ class Dataset(Streamable, MutableMapping[str, Column], Generic[R]):
     def _load_stream(
         cls,
         f: IO[bytes],
-        prefixes: Sequence[str] | None = None,
-        fields: Sequence[str] | None = None,
+        prefixes: Optional[Sequence[str]] = None,
+        fields: Optional[Sequence[str]] = None,
         cstrs: bool = False,
         seekable: bool = False,
     ):

--- a/cryosparc/dataset.py
+++ b/cryosparc/dataset.py
@@ -630,7 +630,7 @@ class Dataset(Streamable, MutableMapping[str, Column], Generic[R]):
         # Use mmap to avoid loading full record array into memory
         # cast path to a string for older numpy/python
         mmap_mode, f = ("r", str(file)) if isinstance(file, (str, PurePath)) else (None, file)
-        indata = n.load(file, mmap_mode=mmap_mode, allow_pickle=False)
+        indata = n.load(f, mmap_mode=mmap_mode, allow_pickle=False)
         size = len(indata)
         descr = filter_descr(indata.dtype.descr, keep_prefixes=prefixes, keep_fields=fields)
         dset = cls.allocate(size, descr)

--- a/cryosparc/dataset.py
+++ b/cryosparc/dataset.py
@@ -645,7 +645,7 @@ class Dataset(Streamable, MutableMapping[str, Column], Generic[R]):
             if mmap_mode and offset < size:
                 # reset mmap to avoid excessive memory usage
                 del indata
-                indata = n.load(file, mmap_mode=mmap_mode, allow_pickle=False)
+                indata = n.load(f, mmap_mode=mmap_mode, allow_pickle=False)
 
         if cstrs:
             dset.to_cstrs()

--- a/cryosparc/dtype.py
+++ b/cryosparc/dtype.py
@@ -3,7 +3,7 @@ Utilities and type definitions for working with dataset fields and column types.
 """
 
 import json
-from typing import TYPE_CHECKING, Dict, List, Tuple, Type, Union
+from typing import TYPE_CHECKING, Dict, List, Optional, Tuple, Type, Union
 
 import numpy as n
 from typing_extensions import Literal, Sequence, TypedDict
@@ -142,8 +142,8 @@ def get_data_field_dtype(data: Data, field: str) -> "DTypeLike":
 def filter_descr(
     descr: List[Field],
     *,
-    keep_prefixes: Sequence[str] | None = None,
-    keep_fields: Sequence[str] | None = None,
+    keep_prefixes: Optional[Sequence[str]] = None,
+    keep_fields: Optional[Sequence[str]] = None,
 ) -> List[Field]:
     # Get a filtered list of fields based on the user-specified prefixies
     # and/or fields. Returns all fields if no filter params are specified.

--- a/cryosparc/dtype.py
+++ b/cryosparc/dtype.py
@@ -42,13 +42,22 @@ Field = Union[Tuple[str, str], Tuple[str, str, Shape]]
 
 class DatasetHeader(TypedDict):
     """
-    Dataset header description when saving in CSDAT format.
+    Encoded dataset file description.
     """
 
     length: int
+    """Number of rows in the dataset"""
+
     dtype: List[Field]
+    """
+    Column description
+    """
+
     compression: Literal["lz4", None]
+    """Compression library used for in the dataset"""
+
     compressed_fields: List[str]
+    """Field names that require decompression."""
 
 
 DSET_TO_TYPE_MAP: Dict[DsetType, Type] = {
@@ -84,13 +93,18 @@ TYPE_TO_DSET_MAP = {
 NEVER_COMPRESS_FIELDS = {"uid"}
 
 
-def makefield(name: str, dtype: "DTypeLike") -> Field:
+def normalize_field(name: str, dtype: "DTypeLike") -> Field:
+    # Note: field name "uid" is always uint64, regardless of given dtype
+    # Note: sd
     dt = n.dtype(dtype)
-    return (name, dt.base.str, dt.shape) if dt.shape else (name, dt.str)
-
-
-def safe_makefield(name: str, dtype: "DTypeLike") -> Field:
-    return ("uid", n.dtype(n.uint64).str) if name == "uid" else makefield(name, dtype)
+    dtstr = dt.str
+    if name == "uid":
+        dtstr = n.dtype(n.uint64).str
+    elif dt.char in {"O", "S", "U"}:  # all python string object types
+        dtstr = n.dtype(object).str
+    elif dt.shape:
+        dtstr = dt.base.str
+    return (name, dtstr, dt.shape) if dt.shape else (name, dtstr)
 
 
 def fielddtype(field: Field) -> DType:
@@ -113,7 +127,7 @@ def dtypestr(dtype: "DTypeLike") -> str:
 
 
 def get_data_field(data: Data, field: str) -> Field:
-    return makefield(field, get_data_field_dtype(data, field))
+    return normalize_field(field, get_data_field_dtype(data, field))
 
 
 def get_data_field_dtype(data: Data, field: str) -> "DTypeLike":
@@ -152,6 +166,11 @@ def decode_dataset_header(data: Union[bytes, dict]) -> DatasetHeader:
         compression: Literal["lz4", None] = header["compression"]
         compressed_fields: List[str] = header["compressed_fields"]
 
-        return DatasetHeader(length=length, dtype=dtype, compression=compression, compressed_fields=compressed_fields)
+        return DatasetHeader(
+            length=length,
+            dtype=dtype,
+            compression=compression,
+            compressed_fields=compressed_fields,
+        )
     except Exception as e:
         raise ValueError(f"Incorrect dataset field format: {data.decode() if isinstance(data, bytes) else data}") from e

--- a/cryosparc/dtype.py
+++ b/cryosparc/dtype.py
@@ -97,14 +97,14 @@ def normalize_field(name: str, dtype: "DTypeLike") -> Field:
     # Note: field name "uid" is always uint64, regardless of given dtype
     # Note: sd
     dt = n.dtype(dtype)
-    dtstr = dt.str
     if name == "uid":
-        dtstr = n.dtype(n.uint64).str
+        return name, n.dtype(n.uint64).str
     elif dt.char in {"O", "S", "U"}:  # all python string object types
-        dtstr = n.dtype(object).str
+        return name, n.dtype(object).str
     elif dt.shape:
-        dtstr = dt.base.str
-    return (name, dtstr, dt.shape) if dt.shape else (name, dtstr)
+        return name, dt.base.str, dt.shape
+    else:
+        return name, dt.str
 
 
 def fielddtype(field: Field) -> DType:

--- a/cryosparc/dtype.py
+++ b/cryosparc/dtype.py
@@ -6,7 +6,7 @@ import json
 from typing import TYPE_CHECKING, Dict, List, Tuple, Type, Union
 
 import numpy as n
-from typing_extensions import Literal, TypedDict
+from typing_extensions import Literal, Sequence, TypedDict
 
 from .core import Data, DsetType
 
@@ -137,6 +137,27 @@ def get_data_field_dtype(data: Data, field: str) -> "DTypeLike":
     dt = n.dtype(DSET_TO_TYPE_MAP[t])
     shape = data.getshp(field)
     return (dt.str, shape) if shape else dt.str
+
+
+def filter_descr(
+    descr: List[Field],
+    *,
+    keep_prefixes: Sequence[str] | None = None,
+    keep_fields: Sequence[str] | None = None,
+) -> List[Field]:
+    # Get a filtered list of fields based on the user-specified prefixies
+    # and/or fields. Returns all fields if no filter params are specified.
+    # Always returns at least uid field, if it exists.
+    filtered: List[Field] = []
+    for field in descr:
+        if (
+            field[0] == "uid"
+            or (keep_prefixes is None and keep_fields is None)
+            or (keep_prefixes is not None and any(field[0].startswith(f"{p}/") for p in keep_prefixes))
+            or (keep_fields is not None and field[0] in keep_fields)
+        ):
+            filtered.append(field)
+    return filtered
 
 
 def encode_dataset_header(fields: DatasetHeader) -> bytes:

--- a/cryosparc/job.py
+++ b/cryosparc/job.py
@@ -1517,7 +1517,7 @@ class ExternalJob(Job):
 
         """
         url = f"/external/projects/{self.project_uid}/jobs/{self.uid}/outputs/{name}/dataset"
-        with make_request(self.cs.vis, url=url, data=dataset.stream()) as res:
+        with make_request(self.cs.vis, url=url, data=dataset.stream(compression="lz4")) as res:
             result = res.read().decode()
             assert res.status >= 200 and res.status < 400, f"Save output failed with message: {result}"
         if refresh:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -295,18 +295,14 @@ def request_callback_rtp(request, uri, response_headers):
 
 
 @pytest.fixture(scope="session")
-def big_dset():
+def big_dset_path():
     basename = "bench_big_dset"
     existing_path = Path.home() / f"{basename}.cs"
 
     print("")  # Keeps printing clean
     if existing_path.exists():
         print(f"Using local sample data {existing_path}; loading...", end="\r")
-        tic = time()
-
-        dset = Dataset.load(existing_path)
-        print(f"Using local sample data {existing_path}; loaded in {time() - tic:.3f} seconds")
-        yield dset
+        yield existing_path
     else:
         import gzip
         import tempfile
@@ -328,10 +324,15 @@ def big_dset():
 
             print("")
             print("Downloaded big dataset sample data; loading...", end="\r")
-            tic = time()
-            dset = Dataset.load(cs_path)
-            print(f"Downloaded big dataset sample data; loaded in {time() - tic:.3f} seconds")
-            yield dset
+            yield cs_path
+
+
+@pytest.fixture(scope="session")
+def big_dset(big_dset_path):
+    tic = time()
+    dset = Dataset.load(big_dset_path)
+    print(f"Loaded big dataset in {time() - tic:.3f} seconds")
+    return dset
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -318,9 +318,8 @@ def big_dset_path():
                 print(f"Downloading big dataset sample data ({total_size} bytes, {progress:.0f}%)", end="\r")
 
             urllib.request.urlretrieve(download_url, compressed_path, reporthook=download_report_hook)
-            with gzip.open(compressed_path, "rb") as compressed_file:
-                with open(cs_path, "wb") as cs_file:
-                    shutil.copyfileobj(compressed_file, cs_file)
+            with gzip.open(compressed_path, "rb") as compressed_file, open(cs_path, "wb") as cs_file:
+                shutil.copyfileobj(compressed_file, cs_file)
 
             print("")
             print("Downloaded big dataset sample data; loading...", end="\r")

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -4,7 +4,7 @@ from io import BytesIO
 import numpy as n
 import pytest
 
-from cryosparc.dataset import Column
+from cryosparc.dataset import CSDAT_FORMAT, Column
 from cryosparc.row import Row
 
 from .conftest import Dataset
@@ -42,10 +42,16 @@ def small_dset():
 
 
 @pytest.fixture
+def small_dset_path(tmp_path, small_dset):
+    path = tmp_path / "small_dset.cs"
+    small_dset.save(path, format=CSDAT_FORMAT)
+    return path
+
+
+@pytest.fixture
 def small_dset_stream(small_dset):
     stream = BytesIO()
-    for dat in small_dset.stream():
-        stream.write(dat)
+    small_dset.save(stream, format=CSDAT_FORMAT)
     stream.seek(0)
     return stream
 
@@ -249,13 +255,13 @@ def test_from_data_none():
     assert len(data) == 0
 
 
-def test_load_stream(small_dset, small_dset_stream):
-    result = Dataset.load(small_dset_stream)
+def test_load_stream(small_dset, small_dset_path):
+    result = Dataset.load(small_dset_path)
     assert result == small_dset
 
 
-def test_load_stream_prefixes(small_dset, small_dset_stream):
-    result = Dataset.load(small_dset_stream, prefixes=["field"])
+def test_load_stream_prefixes(small_dset, small_dset_path):
+    result = Dataset.load(small_dset_path, prefixes=["field"])
     assert result == small_dset.filter_prefixes(["field"], copy=True)
 
 

--- a/tests/test_dataset_bench.py
+++ b/tests/test_dataset_bench.py
@@ -420,7 +420,7 @@ def test_inspect(big_dset_path, fields):
     result = Dataset.inspect(big_dset_path)
     assert result["length"] == 1961726
     assert result["dtype"] == fields
-    assert result["compression"] == None
+    assert result["compression"] is None
     assert result["compressed_fields"] == []
 
 

--- a/tests/test_dataset_bench.py
+++ b/tests/test_dataset_bench.py
@@ -414,3 +414,57 @@ def test_to_cstrs(benchmark, dset: Dataset):
 def test_to_pystrs(benchmark, dset_cstrs: Dataset):
     result: Dataset = benchmark(dset_cstrs.to_pystrs, copy=True)
     assert result["ctf/type"].dtype.type == n.object_
+
+
+def test_inspect(big_dset_path, fields):
+    result = Dataset.inspect(big_dset_path)
+    assert result["length"] == 1961726
+    assert result["dtype"] == fields
+    assert result["compression"] == None
+    assert result["compressed_fields"] == []
+
+
+def test_load(benchmark, big_dset_path, fields):
+    result = benchmark(Dataset.load, big_dset_path)
+    assert len(result) == 1961726
+    assert result.descr() == fields
+
+
+def test_load_prefixes(benchmark, big_dset_path, fields):
+    keep_prefixes = ["location", "pick_stats"]
+    expected_fields = [
+        field
+        for field in fields
+        if field[0] == "uid" or field[0].startswith("location/") or field[0].startswith("pick_stats/")
+    ]
+    result = benchmark(Dataset.load, big_dset_path, prefixes=keep_prefixes)
+    assert len(result) == 1961726
+    assert result.descr() == expected_fields
+
+
+def test_load_fields(benchmark, big_dset_path, fields):
+    keep_fields = ["ctf/type", "ctf/shift_A", "location/micrograph_uid"]
+    result = benchmark(Dataset.load, big_dset_path, fields=keep_fields)
+    assert len(result) == 1961726
+    assert result.descr() == [
+        ("uid", "<u8"),
+        ("ctf/type", "|O"),
+        ("ctf/shift_A", "<f4", (2,)),
+        ("location/micrograph_uid", "<u8"),
+    ]
+
+
+def test_load_prefixes_fields(benchmark, big_dset_path, fields):
+    keep_prefixes = ["location", "pick_stats"]
+    keep_fields = ["ctf/type", "ctf/shift_A", "location/micrograph_uid"]
+    result = benchmark(Dataset.load, big_dset_path, prefixes=keep_prefixes, fields=keep_fields)
+    expected_fields = [
+        field
+        for field in fields
+        if field[0] == "uid"
+        or field[0].startswith("location/")
+        or field[0].startswith("pick_stats/")
+        or field[0] in keep_fields
+    ]
+    assert len(result) == 1961726
+    assert result.descr() == expected_fields


### PR DESCRIPTION
- New `Dataset.inspect` function for reading dataset headers
- Use chunked mmap loading for numpy arrays
- Break `load` into helper functions