### PR TITLE
Release v4.6.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
       - id: check-yaml
       - id: check-added-large-files
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.6.2
+    rev: v0.6.4
     hooks:
       - id: ruff
         name: ruff check
@@ -24,7 +24,7 @@ repos:
         name: ruff format
         alias: format
   - repo: https://github.com/RobertCraigie/pyright-python
-    rev: v1.1.377
+    rev: v1.1.379
     hooks:
       - id: pyright
         additional_dependencies: [cython, httpretty, numpy, pytest]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,13 +10,21 @@ repos:
       - id: check-yaml
       - id: check-added-large-files
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.5.6
+    rev: v0.6.2
     hooks:
       - id: ruff
+        name: ruff check
+        alias: check
+        args: [--fix]
+      - id: ruff
+        name: ruff check imports
+        alias: check-imports
         args: [--fix, --select, I, --exit-non-zero-on-fix]
       - id: ruff-format
+        name: ruff format
+        alias: format
   - repo: https://github.com/RobertCraigie/pyright-python
-    rev: v1.1.374
+    rev: v1.1.377
     hooks:
       - id: pyright
         additional_dependencies: [cython, httpretty, numpy, pytest]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## v4.6.0
+
+- Added: `Dataset.is_equivalent` method to check if two datasets have identical fields, but in a different order
+- Added: `Dataset.inspect` class method which accepts a path to a dataset and returns its header without loading the entire dataset from disk
+- Added: Load a subset of dataset fields with `Dataset.load` by specifying `prefixes` or `fields` keyword arguments
+- Added: Support for uploading job assets in `bild` format
+- Updated: `ExternalJob.add_output` method now expects `alloc` argument to be specified as a keyword arg
+- Updated: Dataset methods which accept a `copy` argument now expect it to be specified as a keyword arg
+- Fixed: Significantly reduced memory when loading large datasets with `Dataset.load`
+
 ## v4.5.1
 
 - Added: Numpy 2.0 support

--- a/cryosparc/__init__.py
+++ b/cryosparc/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "4.5.1"
+__version__ = "4.6.0"
 
 
 def get_include():

--- a/cryosparc/column.py
+++ b/cryosparc/column.py
@@ -68,6 +68,15 @@ class Column(n.ndarray):
         # or n.median
         return obj[()] if obj.shape == () else super().__array_wrap__(obj, context, return_scalar)  # type: ignore
 
+    def __setitem__(self, key, value):
+        if isinstance(value, n.ndarray):
+            # parse fixed-size size strings
+            if value.dtype.char == "S":
+                value = n.vectorize(hashcache(bytes.decode), otypes="O")(value)
+            elif value.dtype.char == "U":
+                value = n.vectorize(hashcache(str), otypes="O")(value)
+        return super().__setitem__(key, value)
+
     def to_fixed(self) -> "Column":
         """
         If this Column is composed of Python objects, convert to fixed-size

--- a/cryosparc/dataset.py
+++ b/cryosparc/dataset.py
@@ -501,7 +501,7 @@ class Dataset(Streamable, MutableMapping[str, Column], Generic[R]):
         # [0,1,2]}), …]. This is faster than doing the innerjoin for all columns
         # and safer because we don't have to worry about not updating Python
         # string reference counts in the resulting dataset.
-        indexed_dsets = [Dataset({"uid": d["uid"], f"idx{i}": n.arange(len(d))}) for i, d in enumerate(datasets)]
+        indexed_dsets = [cls({"uid": d["uid"], f"idx{i}": n.arange(len(d))}) for i, d in enumerate(datasets)]
         indexed_dset = reduce(lambda dr, ds: cls(dr._data.innerjoin("uid", ds._data)), indexed_dsets)
         result = cls({"uid": indexed_dset["uid"]})
         result.add_fields(all_fields)
@@ -856,7 +856,7 @@ class Dataset(Streamable, MutableMapping[str, Column], Generic[R]):
         """
         return (
             isinstance(other, type(self))
-            and type(self) == type(other)
+            and type(self) is type(other)
             and len(self) == len(other)
             and self.descr() == other.descr()
             and all(n.array_equal(self[c1], other[c2]) for c1, c2 in zip(self, other))

--- a/cryosparc/dataset.py
+++ b/cryosparc/dataset.py
@@ -820,7 +820,7 @@ class Dataset(Streamable, MutableMapping[str, Column], Generic[R]):
             Data,
             Mapping[str, "ArrayLike"],
             List[Tuple[str, "ArrayLike"]],
-            Literal[None],
+            None,
         ] = 0,
         row_class=Row,
     ):
@@ -1084,7 +1084,7 @@ class Dataset(Streamable, MutableMapping[str, Column], Generic[R]):
     def add_fields(
         self,
         fields: Union[Sequence[str], Sequence[Field]],
-        dtypes: Union[str, Sequence["DTypeLike"], Literal[None]] = None,
+        dtypes: Union[str, Sequence["DTypeLike"], None] = None,
     ) -> "Dataset[R]":
         """
         Adds the given fields to the dataset. If a field with the same name

--- a/cryosparc/job.py
+++ b/cryosparc/job.py
@@ -1517,7 +1517,7 @@ class ExternalJob(Job):
 
         """
         url = f"/external/projects/{self.project_uid}/jobs/{self.uid}/outputs/{name}/dataset"
-        with make_request(self.cs.vis, url=url, data=dataset.stream()) as res:
+        with make_request(self.cs.vis, url=url, data=dataset.stream(compression="lz4")) as res:
             result = res.read().decode()
             assert res.status >= 200 and res.status < 400, f"Save output failed with message: {result}"
         if refresh:

--- a/cryosparc/job.py
+++ b/cryosparc/job.py
@@ -496,8 +496,8 @@ class Job(MongoController[JobDocument]):
         figure: Union[str, PurePath, IO[bytes], Any],
         text: str,
         formats: Iterable[ImageFormat] = ["png", "pdf"],
-        raw_data: Union[str, bytes, Literal[None]] = None,
-        raw_data_file: Union[str, PurePath, IO[bytes], Literal[None]] = None,
+        raw_data: Union[str, bytes, None] = None,
+        raw_data_file: Union[str, PurePath, IO[bytes], None] = None,
         raw_data_format: Optional[TextFormat] = None,
         flags: List[str] = ["plots"],
         savefig_kw: dict = dict(bbox_inches="tight", pad_inches=0),
@@ -767,8 +767,8 @@ class Job(MongoController[JobDocument]):
         figure: Union[str, PurePath, IO[bytes], Any],
         name: Optional[str] = None,
         formats: Iterable[ImageFormat] = ["png", "pdf"],
-        raw_data: Union[str, bytes, Literal[None]] = None,
-        raw_data_file: Union[str, PurePath, IO[bytes], Literal[None]] = None,
+        raw_data: Union[str, bytes, None] = None,
+        raw_data_file: Union[str, PurePath, IO[bytes], None] = None,
         raw_data_format: Optional[TextFormat] = None,
         savefig_kw: dict = dict(bbox_inches="tight", pad_inches=0),
     ) -> List[EventLogAsset]:
@@ -965,7 +965,7 @@ class Job(MongoController[JobDocument]):
         args: Union[str, list],
         mute: bool = False,
         checkpoint: bool = False,
-        checkpoint_line_pattern: Union[str, Pattern[str], Literal[None]] = None,
+        checkpoint_line_pattern: Union[str, Pattern[str], None] = None,
         **kwargs,
     ):
         """
@@ -1258,7 +1258,8 @@ class ExternalJob(Job):
         name: Optional[str] = ...,
         slots: List[SlotSpec] = ...,
         passthrough: Optional[str] = ...,
-        title: Optional[str] = None,
+        title: Optional[str] = ...,
+        *,
         alloc: Literal[None] = None,
     ) -> str: ...
     @overload
@@ -1268,7 +1269,8 @@ class ExternalJob(Job):
         name: Optional[str] = ...,
         slots: List[SlotSpec] = ...,
         passthrough: Optional[str] = ...,
-        title: Optional[str] = None,
+        title: Optional[str] = ...,
+        *,
         alloc: Union[int, Dataset] = ...,
     ) -> Dataset: ...
     def add_output(
@@ -1278,7 +1280,8 @@ class ExternalJob(Job):
         slots: List[SlotSpec] = [],
         passthrough: Optional[str] = None,
         title: Optional[str] = None,
-        alloc: Union[int, Dataset, Literal[None]] = None,
+        *,
+        alloc: Union[int, Dataset, None] = None,
     ) -> Union[str, Dataset]:
         """
         Add an output slot to the current job. Optionally returns the

--- a/cryosparc/spec.py
+++ b/cryosparc/spec.py
@@ -66,7 +66,7 @@ Possible job status values.
 """
 
 # Valid plot file types
-TextFormat = Literal["txt", "csv", "html", "json", "xml"]
+TextFormat = Literal["txt", "csv", "html", "json", "xml", "bild", "bld"]
 """
 Supported job stream log asset file text formats.
 """
@@ -87,6 +87,7 @@ TextContentType = Literal[
     "text/html",
     "application/json",
     "application/xml",
+    "application/x-troff",
 ]
 """
 Supported job stream log text asset MIME types.
@@ -114,6 +115,8 @@ TEXT_CONTENT_TYPES: Dict[TextFormat, TextContentType] = {
     "html": "text/html",
     "json": "application/json",
     "xml": "application/xml",
+    "bild": "application/x-troff",
+    "bld": "application/x-troff",
 }
 
 IMAGE_CONTENT_TYPES: Dict[ImageFormat, ImageContentType] = {
@@ -126,7 +129,7 @@ IMAGE_CONTENT_TYPES: Dict[ImageFormat, ImageContentType] = {
 }
 
 ASSET_CONTENT_TYPES: Dict[AssetFormat, AssetContentType] = {**TEXT_CONTENT_TYPES, **IMAGE_CONTENT_TYPES}  # type: ignore
-ASSET_EXTENSIONS = {v: k for k, v in ASSET_CONTENT_TYPES.items()}
+ASSET_EXTENSIONS: Dict[AssetContentType, AssetFormat] = {v: k for k, v in ASSET_CONTENT_TYPES.items()}
 
 
 class AssetDetails(TypedDict):

--- a/cryosparc/tools.py
+++ b/cryosparc/tools.py
@@ -757,7 +757,7 @@ class CryoSPARC:
                     # headers. If cannot be determined, defaults to "file.dat"
                     content_type: str = response.headers.get_content_type()
                     attachment_filename: Optional[str] = response.headers.get_filename()
-                    target /= attachment_filename or f"file.{ASSET_EXTENSIONS.get(content_type, 'dat')}"
+                    target /= attachment_filename or f"file.{ASSET_EXTENSIONS.get(content_type, 'dat')}"  # type: ignore
             with bopen(target, "wb") as f:
                 data = response.read(ONE_MIB)
                 while data:

--- a/cryosparc/util.py
+++ b/cryosparc/util.py
@@ -320,7 +320,7 @@ def random_integers(
     rng: "n.random.Generator",
     low: int,
     high: Optional[int] = None,
-    size: Union[int, Shape, Literal[None]] = None,
+    size: Union[int, Shape, None] = None,
     dtype: Type[INT] = n.uint64,
 ) -> "NDArray[INT]":
     """

--- a/docs/examples/connect_series_to_class3D.ipynb
+++ b/docs/examples/connect_series_to_class3D.ipynb
@@ -79,10 +79,10 @@
     }
    ],
    "source": [
+    "import zipfile\n",
+    "\n",
     "unzip_path = series_path[:-4]\n",
     "print(unzip_path)\n",
-    "\n",
-    "import zipfile\n",
     "\n",
     "with zipfile.ZipFile(series_path, \"r\") as z:\n",
     "    z.extractall(unzip_path)"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cryosparc-tools"
-version = "4.5.1"
+version = "4.6.0"
 description = "Toolkit for interfacing with CryoSPARC"
 readme = "README.md"
 requires-python = ">=3.7"

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ elif DEBUG:
 
 setup(
     name="cryosparc_tools",
-    version="4.5.1",
+    version="4.6.0",
     description="Toolkit for interfacing with CryoSPARC",
     headers=["cryosparc/include/cryosparc-tools/dataset.h"],
     ext_modules=cythonize(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -295,18 +295,14 @@ def request_callback_rtp(request, uri, response_headers):
 
 
 @pytest.fixture(scope="session")
-def big_dset():
+def big_dset_path():
     basename = "bench_big_dset"
     existing_path = Path.home() / f"{basename}.cs"
 
     print("")  # Keeps printing clean
     if existing_path.exists():
         print(f"Using local sample data {existing_path}; loading...", end="\r")
-        tic = time()
-
-        dset = Dataset.load(existing_path)
-        print(f"Using local sample data {existing_path}; loaded in {time() - tic:.3f} seconds")
-        yield dset
+        yield existing_path
     else:
         import gzip
         import tempfile
@@ -322,16 +318,20 @@ def big_dset():
                 print(f"Downloading big dataset sample data ({total_size} bytes, {progress:.0f}%)", end="\r")
 
             urllib.request.urlretrieve(download_url, compressed_path, reporthook=download_report_hook)
-            with gzip.open(compressed_path, "rb") as compressed_file:
-                with open(cs_path, "wb") as cs_file:
-                    shutil.copyfileobj(compressed_file, cs_file)
+            with gzip.open(compressed_path, "rb") as compressed_file, open(cs_path, "wb") as cs_file:
+                shutil.copyfileobj(compressed_file, cs_file)
 
             print("")
             print("Downloaded big dataset sample data; loading...", end="\r")
-            tic = time()
-            dset = Dataset.load(cs_path)
-            print(f"Downloaded big dataset sample data; loaded in {time() - tic:.3f} seconds")
-            yield dset
+            yield cs_path
+
+
+@pytest.fixture(scope="session")
+def big_dset(big_dset_path):
+    tic = time()
+    dset = Dataset.load(big_dset_path)
+    print(f"Loaded big dataset in {time() - tic:.3f} seconds")
+    return dset
 
 
 @pytest.fixture

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -254,8 +254,8 @@ def test_pickle_unpickle():
 
 
 def test_column_aggregation(t20s_dset):
-    assert type(t20s_dset["uid"]) == Column
-    assert type(n.max(t20s_dset["uid"])) == n.uint64
+    assert type(t20s_dset["uid"]) is Column
+    assert type(n.max(t20s_dset["uid"])) is n.uint64
     assert isinstance(n.mean(t20s_dset["uid"]), n.number)
     assert not isinstance(n.mean(t20s_dset["uid"]), n.ndarray)
 

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -4,7 +4,7 @@ from io import BytesIO
 import numpy as n
 import pytest
 
-from cryosparc.dataset import Column
+from cryosparc.dataset import CSDAT_FORMAT, Column
 from cryosparc.row import Row
 
 from .conftest import Dataset
@@ -22,6 +22,38 @@ def io_data():
         )
     )
     return BytesIO(data)
+
+
+@pytest.fixture
+def small_dset():
+    field3 = "long/fieldwithsuperduperlongcolumnnamethatislongandtestable"
+    dset = Dataset.allocate(
+        4,
+        fields=[
+            ("field/1", "u8", (2,)),
+            ("field/2", "f4"),
+            (field3, "O"),
+        ],
+    )
+    dset["field/1"] = (42, 43)
+    dset["field/2"] = n.array([3.14, 2.73, 1.62, 3.14], dtype="f8")
+    dset[field3][:] = n.array(["Hello", "World", "!", "!"])
+    return dset
+
+
+@pytest.fixture
+def small_dset_path(tmp_path, small_dset):
+    path = tmp_path / "small_dset.cs"
+    small_dset.save(path, format=CSDAT_FORMAT)
+    return path
+
+
+@pytest.fixture
+def small_dset_stream(small_dset):
+    stream = BytesIO()
+    small_dset.save(stream, format=CSDAT_FORMAT)
+    stream.seek(0)
+    return stream
 
 
 def test_allocate():
@@ -173,7 +205,7 @@ def test_to_list_exclude_uid():
     assert lst == [[0, 0.0, "Hello"]]
 
 
-def test_to_file():
+def test_save():
     dtype = [("uid", "u8"), ("field1", "u4"), ("field2", "f4"), ("field3", "S6"), ("field4", "f8")]
     expected = n.array([(1, 42, 3.14, "Hello", 1.0), (2, 42, 2.73, "World", 0.0)], dtype=dtype)
     dset = Dataset(expected)
@@ -186,18 +218,28 @@ def test_to_file():
     assert all(e.decode() == a.decode() for e, a in zip(expected["field3"], actual["field3"]))
 
 
-def test_from_file(io_data):
+def test_load(io_data):
     dtype = [("field1", "u4"), ("field2", "f4"), ("field3", "O"), ("field4", "f8"), ("field5", "i8")]
-
-    result = Dataset.load(io_data)
     expected = Dataset.allocate(size=2, fields=dtype)
-
     expected["field1"] = 42
     expected["field2"] = n.array([3.14, 2.73], dtype="f8")
     expected["field3"][:] = n.array(["Hello", "World"])
     expected["field4"][1] = 1.0
     expected["field5"][0:] = 43
 
+    result = Dataset.load(io_data)
+    assert expected.descr() == result.descr()
+    assert all([n.equal(expected[d[0]], result[d[0]]).all() for d in dtype if d[0] != "uid"])
+
+
+def test_load_fields(io_data):
+    dtype = [("field2", "f4"), ("field3", "O"), ("field5", "i8")]
+    expected = Dataset.allocate(size=2, fields=dtype)
+    expected["field2"] = n.array([3.14, 2.73], dtype="f8")
+    expected["field3"][:] = n.array(["Hello", "World"])
+    expected["field5"][0:] = 43
+
+    result = Dataset.load(io_data, fields=["field2", "field3", "field5"])
     assert expected.descr() == result.descr()
     assert all([n.equal(expected[d[0]], result[d[0]]).all() for d in dtype if d[0] != "uid"])
 
@@ -213,27 +255,19 @@ def test_from_data_none():
     assert len(data) == 0
 
 
-def test_streaming_bytes():
-    field3 = "fieldwithsuperduperlongcolumnnamethatislongandtestable"
-    dset = Dataset.allocate(
-        4,
-        fields=[
-            ("field1", "u8"),
-            ("field2", "f4"),
-            (field3, "O"),
-        ],
-    )
-    dset["field1"] = 42
-    dset["field2"] = n.array([3.14, 2.73, 1.62, 3.14], dtype="f8")
-    dset[field3][:] = n.array(["Hello", "World", "!", "!"])
+def test_load_stream(small_dset, small_dset_path):
+    result = Dataset.load(small_dset_path)
+    assert result == small_dset
 
-    stream = BytesIO()
-    for dat in dset.stream():
-        stream.write(dat)
-    stream.seek(0)
-    result = dset.load(stream)
 
-    assert dset == result
+def test_load_stream_prefixes(small_dset, small_dset_path):
+    result = Dataset.load(small_dset_path, prefixes=["field"])
+    assert result == small_dset.filter_prefixes(["field"], copy=True)
+
+
+def test_load_stream_fields(small_dset, small_dset_stream):
+    result = Dataset.load(small_dset_stream, fields=["field/2"])
+    assert result == small_dset.filter_fields(["field/2"], copy=True)
 
 
 def test_pickle_unpickle():


### PR DESCRIPTION
## Changelog

### New

- `Dataset.is_equivalent` method to check if two datasets have identical fields, but in a different order
- `Dataset.inspect`  class method which accepts a path to a dataset and returns its header without loading the entire dataset from disk
- Load a subset of dataset fields with `Dataset.load`  by specifying `prefixes` or `fields` keyword arguments
- Support for uploading job assets in `bild` format

### Updated

- `ExternalJob.add_output` method now expects `alloc` argument to be specified as a keyword arg
- Dataset methods which accept a `copy` argument now expect it to be specified as a keyword arg

### Fixed

- Significantly reduced memory usage when loading large datasets with `Dataset.load`