### PR TITLE
CI: build fixes for v4.6

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -88,8 +88,8 @@ jobs:
           pytest -v --benchmark-disable -n auto
 
   build:
-    needs: [test]
-    if: "startsWith(github.ref, 'refs/tags/')"
+    # needs: [test]
+    # if: "startsWith(github.ref, 'refs/tags/')"
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: true
@@ -104,7 +104,7 @@ jobs:
         uses: docker/setup-qemu-action@v3
         with:
           platforms: arm64
-      - uses: pypa/cibuildwheel@v2.17.0
+      - uses: pypa/cibuildwheel@v2.20.0
         env:
           CIBW_SKIP: cp36-* pp*-win* pp*-macosx* *_i686
           CIBW_TEST_SKIP: "*-win_arm64"

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -96,6 +96,7 @@ jobs:
   foo:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
       - name: Output commit message
         run: |
           {

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -100,8 +100,7 @@ jobs:
   # NOTE: build step only runs on tag builds or when the commit message contains
   # "[ci build]" for testing
   build:
-    # needs: [lint, test]
-    needs: [lint]
+    needs: [lint, test]
     if: "${{ startsWith(github.ref, 'refs/tags/') || contains(needs.lint.outputs.commit-message, '[ci build]') }}"
     runs-on: ${{ matrix.os }}
     strategy:

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -49,13 +49,13 @@ jobs:
         with:
           name: wheels
           path: dist
-      - name: Check for [ci build] in commit message
+      - name: Output commit message
         run: |
-          if git log -1 --pretty=format:"%B" | grep "\[ci build\]" ; then
-            echo "force-build=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "force-build=false" >> "$GITHUB_OUTPUT"
-          fi
+          {
+            echo 'commit-message<<CI_EOF'
+            git show -s --format="%B"
+            echo CI_EOF
+          } >> "$GITHUB_OUTPUT"
 
   test:
     needs: [lint]
@@ -97,14 +97,14 @@ jobs:
     needs: [lint]
     runs-on: ubuntu-latest
     steps:
-      - run: echo "${{ needs.lint.outputs.force-build }}"
+      - run: echo "${{ needs.lint.outputs.commit-message }}"
 
   # NOTE: build step only runs on tag builds or when the commit message contains
   # "[ci build]" for testing
   build:
     # needs: [lint, test]
     needs: [lint]
-    if: "${{ startsWith(github.ref, 'refs/tags/') || needs.lint.outputs.force-build == 'true' }}"
+    if: "${{ startsWith(github.ref, 'refs/tags/') || contains(needs.lint.outputs.commit-message, '[ci build]') }}"
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: true

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -96,15 +96,18 @@ jobs:
 
   foo:
     runs-on: ubuntu-latest
+    outputs:
+      commit-message: ${{ steps.get-commit-message.outputs.commit-message }}
     steps:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }} # gets correct commit message
       - name: Output commit message
+        id: get-commit-message
         run: |
           git show -s --format="%B"
           {
-            echo 'commit<<CI_EOF'
+            echo 'commit-message<<CI_EOF'
             git show -s --format="%B"
             echo CI_EOF
           } >> "$GITHUB_OUTPUT"
@@ -114,7 +117,7 @@ jobs:
     needs: [foo]
     steps:
       - name: Get commit message
-        run: echo "${{ needs.foo.outputs.commit }}"
+        run: echo "${{ needs.foo.outputs.commit-message }}"
 
   # NOTE: build step only runs on tag builds or when the commit message contains
   # "[ci build]" for testing

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -109,8 +109,7 @@ jobs:
   # NOTE: build step only runs on tag builds or when the commit message contains
   # "[ci build]" for testing
   build:
-    # needs: [meta, test]
-    needs: [meta]
+    needs: [meta, test]
     if: "${{ startsWith(github.ref, 'refs/tags/') || contains(needs.meta.outputs.commit-message, '[ci build]') }}"
     runs-on: ${{ matrix.os }}
     strategy:

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -22,10 +22,27 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  lint:
+  meta:
     runs-on: ubuntu-latest
     outputs:
       commit-message: ${{ steps.get-commit-message.outputs.commit-message }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }} # gets correct commit message
+      - name: Show commit
+        run: git show -s
+      - name: Output commit message
+        id: get-commit-message
+        run: |
+          {
+            echo 'commit-message<<CI_EOF'
+            git show -s --format="%B"
+            echo CI_EOF
+          } >> "$GITHUB_OUTPUT"
+
+  lint:
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:
@@ -52,14 +69,6 @@ jobs:
         with:
           name: wheels
           path: dist
-      - name: Output commit message
-        id: get-commit-message
-        run: |
-          {
-            echo 'commit-message<<CI_EOF'
-            git show -s --format="%B"
-            echo CI_EOF
-          } >> "$GITHUB_OUTPUT"
 
   test:
     needs: [lint]
@@ -100,8 +109,9 @@ jobs:
   # NOTE: build step only runs on tag builds or when the commit message contains
   # "[ci build]" for testing
   build:
-    needs: [lint, test]
-    if: "${{ startsWith(github.ref, 'refs/tags/') || contains(needs.lint.outputs.commit-message, '[ci build]') }}"
+    # needs: [meta, test]
+    needs: [meta]
+    if: "${{ startsWith(github.ref, 'refs/tags/') || contains(needs.meta.outputs.commit-message, '[ci build]') }}"
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: true

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -107,10 +107,10 @@ jobs:
           pytest -v --benchmark-disable -n auto
 
   # NOTE: build step only runs on tag builds or when the commit message contains
-  # "[ci build]" for testing
+  # "[ci test build]" for testing
   build:
     needs: [meta, test]
-    if: "${{ startsWith(github.ref, 'refs/tags/') || contains(needs.meta.outputs.commit-message, '[ci build]') }}"
+    if: "${{ startsWith(github.ref, 'refs/tags/') || contains(needs.meta.outputs.commit-message, '[ci test build]') }}"
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: true

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -96,12 +96,37 @@ jobs:
         run: |
           pytest -v --benchmark-disable -n auto
 
+  foo:
+    runs-on: ubuntu-latest
+    outputs:
+      commit-message: ${{ steps.get-commit-message.outputs.commit-message }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }} # gets correct commit message
+      - name: Output commit message
+        id: get-commit-message
+        run: |
+          git show -s --format="%B"
+          {
+            echo 'commit-message<<CI_EOF'
+            git show -s --format="%B"
+            echo CI_EOF
+          } >> "$GITHUB_OUTPUT"
+
+  bar:
+    runs-on: ubuntu-latest
+    needs: [foo]
+    steps:
+      - name: Get commit message
+        run: echo "${{ needs.foo.outputs.commit-message }}"
+
   # NOTE: build step only runs on tag builds or when the commit message contains
   # "[ci build]" for testing
   build:
     # needs: [lint, test]
-    needs: [lint]
-    if: "${{ startsWith(github.ref, 'refs/tags/') || contains(needs.lint.outputs.commit-message, '[ci build]') }}"
+    needs: [foo]
+    if: "${{ startsWith(github.ref, 'refs/tags/') || contains(needs.foo.outputs.commit-message, '[ci build]') }}"
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: true

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -99,11 +99,19 @@ jobs:
       - uses: actions/checkout@v4
       - name: Output commit message
         run: |
+          git show -s --format="%B"
           {
             echo 'commit<<CI_EOF'
             git show -s --format="%B"
             echo CI_EOF
           } >> "$GITHUB_OUTPUT"
+
+  bar:
+    runs-on: ubuntu-latest
+    needs: [foo]
+    steps:
+      - name: Get commit message
+        run: echo "${{ needs.foo.outputs.commit }}"
 
   # NOTE: build step only runs on tag builds or when the commit message contains
   # "[ci build]" for testing

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -89,7 +89,7 @@ jobs:
 
   build:
     needs: [test]
-    if: ${{ startsWith(github.ref, 'refs/tags/') or contains(github.event.head_commit.message, '[ci build]') }}
+    if: ${{ startsWith(github.ref, 'refs/tags/') || contains(github.event.head_commit.message, '[ci build]') }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: true

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -88,8 +88,8 @@ jobs:
           pytest -v --benchmark-disable -n auto
 
   build:
-    # needs: [test]
-    # if: "startsWith(github.ref, 'refs/tags/')"
+    needs: [test]
+    if: "startsWith(github.ref, 'refs/tags/')"
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: true

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -49,6 +49,13 @@ jobs:
         with:
           name: wheels
           path: dist
+      - name: Check for [ci build] in commit message
+        run: |
+          if git log -1 --pretty=format:"%B" | grep "\[ci build\]" ; then
+            echo "force-build=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "force-build=false" >> "$GITHUB_OUTPUT"
+          fi
 
   test:
     needs: [lint]
@@ -63,7 +70,6 @@ jobs:
           # https://github.com/actions/setup-python/issues/852
           - os: macos-latest
             python-version: "3.7"
-
     steps:
       - uses: actions/checkout@v4
         with:
@@ -87,9 +93,12 @@ jobs:
         run: |
           pytest -v --benchmark-disable -n auto
 
+  # NOTE: build step only runs on tag builds or when the commit message contains
+  # "[ci build]" for testing
   build:
-    needs: [test]
-    if: ${{ startsWith(github.ref, 'refs/tags/') || contains(github.event.head_commit.message, '[ci build]') }}
+    # needs: [lint, test]
+    needs: [lint]
+    if: "startsWith(github.ref, 'refs/tags/') || needs.lint.outputs.force-build == 'true'"
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: true
@@ -118,6 +127,7 @@ jobs:
           name: wheels-${{ runner.os }}
           path: dist
 
+  # NOTE: release step only runs on tag builds
   release:
     name: Release
     runs-on: ubuntu-latest

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Output commit message
         run: |
           {
-            echo 'commit-message<<CI_EOF'
+            echo 'commit<<CI_EOF'
             git show -s --format="%B"
             echo CI_EOF
           } >> "$GITHUB_OUTPUT"
@@ -94,17 +94,22 @@ jobs:
           pytest -v --benchmark-disable -n auto
 
   foo:
-    needs: [lint]
     runs-on: ubuntu-latest
     steps:
-      - run: echo "${{ needs.lint.outputs.commit-message }}"
+      - name: Output commit message
+        run: |
+          {
+            echo 'commit<<CI_EOF'
+            git show -s --format="%B"
+            echo CI_EOF
+          } >> "$GITHUB_OUTPUT"
 
   # NOTE: build step only runs on tag builds or when the commit message contains
   # "[ci build]" for testing
   build:
     # needs: [lint, test]
-    needs: [lint]
-    if: "${{ startsWith(github.ref, 'refs/tags/') || contains(needs.lint.outputs.commit-message, '[ci build]') }}"
+    needs: [foo]
+    if: "${{ startsWith(github.ref, 'refs/tags/') || contains(needs.foo.outputs.commit, '[ci build]') }}"
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: true

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -28,6 +28,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: true
+          ref: ${{ github.event.pull_request.head.sha }} # gets correct commit message
       - uses: actions/setup-python@v5
         with:
           python-version: "3.10"
@@ -97,6 +98,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }} # gets correct commit message
       - name: Output commit message
         run: |
           git show -s --format="%B"

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -93,12 +93,18 @@ jobs:
         run: |
           pytest -v --benchmark-disable -n auto
 
+  foo:
+    needs: [lint]
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "${{ needs.lint.outputs.force-build }}"
+
   # NOTE: build step only runs on tag builds or when the commit message contains
   # "[ci build]" for testing
   build:
     # needs: [lint, test]
     needs: [lint]
-    if: "startsWith(github.ref, 'refs/tags/') || needs.lint.outputs.force-build == 'true'"
+    if: "${{ startsWith(github.ref, 'refs/tags/') || needs.lint.outputs.force-build == 'true' }}"
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: true

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -24,6 +24,8 @@ concurrency:
 jobs:
   lint:
     runs-on: ubuntu-latest
+    outputs:
+      commit-message: ${{ steps.get-commit-message.outputs.commit-message }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -53,7 +55,7 @@ jobs:
       - name: Output commit message
         run: |
           {
-            echo 'commit<<CI_EOF'
+            echo 'commit-message<<CI_EOF'
             git show -s --format="%B"
             echo CI_EOF
           } >> "$GITHUB_OUTPUT"
@@ -94,37 +96,12 @@ jobs:
         run: |
           pytest -v --benchmark-disable -n auto
 
-  foo:
-    runs-on: ubuntu-latest
-    outputs:
-      commit-message: ${{ steps.get-commit-message.outputs.commit-message }}
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.sha }} # gets correct commit message
-      - name: Output commit message
-        id: get-commit-message
-        run: |
-          git show -s --format="%B"
-          {
-            echo 'commit-message<<CI_EOF'
-            git show -s --format="%B"
-            echo CI_EOF
-          } >> "$GITHUB_OUTPUT"
-
-  bar:
-    runs-on: ubuntu-latest
-    needs: [foo]
-    steps:
-      - name: Get commit message
-        run: echo "${{ needs.foo.outputs.commit-message }}"
-
   # NOTE: build step only runs on tag builds or when the commit message contains
   # "[ci build]" for testing
   build:
     # needs: [lint, test]
-    needs: [foo]
-    if: "${{ startsWith(github.ref, 'refs/tags/') || contains(needs.foo.outputs.commit, '[ci build]') }}"
+    needs: [lint]
+    if: "${{ startsWith(github.ref, 'refs/tags/') || contains(needs.lint.outputs.commit-message, '[ci build]') }}"
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: true

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -89,7 +89,7 @@ jobs:
 
   build:
     needs: [test]
-    if: "startsWith(github.ref, 'refs/tags/')"
+    if: ${{ startsWith(github.ref, 'refs/tags/') or contains(github.event.head_commit.message, '[ci build]') }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: true
@@ -121,7 +121,7 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
-    if: "startsWith(github.ref, 'refs/tags/')"
+    if: ${{ startsWith(github.ref, 'refs/tags/') }}
     needs: [build]
     steps:
       - uses: actions/download-artifact@v4

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -53,6 +53,7 @@ jobs:
           name: wheels
           path: dist
       - name: Output commit message
+        id: get-commit-message
         run: |
           {
             echo 'commit-message<<CI_EOF'
@@ -96,37 +97,12 @@ jobs:
         run: |
           pytest -v --benchmark-disable -n auto
 
-  foo:
-    runs-on: ubuntu-latest
-    outputs:
-      commit-message: ${{ steps.get-commit-message.outputs.commit-message }}
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.sha }} # gets correct commit message
-      - name: Output commit message
-        id: get-commit-message
-        run: |
-          git show -s --format="%B"
-          {
-            echo 'commit-message<<CI_EOF'
-            git show -s --format="%B"
-            echo CI_EOF
-          } >> "$GITHUB_OUTPUT"
-
-  bar:
-    runs-on: ubuntu-latest
-    needs: [foo]
-    steps:
-      - name: Get commit message
-        run: echo "${{ needs.foo.outputs.commit-message }}"
-
   # NOTE: build step only runs on tag builds or when the commit message contains
   # "[ci build]" for testing
   build:
     # needs: [lint, test]
-    needs: [foo]
-    if: "${{ startsWith(github.ref, 'refs/tags/') || contains(needs.foo.outputs.commit-message, '[ci build]') }}"
+    needs: [lint]
+    if: "${{ startsWith(github.ref, 'refs/tags/') || contains(needs.lint.outputs.commit-message, '[ci build]') }}"
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: true


### PR DESCRIPTION
- bump pypa/cibuildwheel to v2.20.0
- allow testing build by including `[ci test build]` in the commit message ([figured out how to do it from this discussion](https://github.com/orgs/community/discussions/28474))