### PR TITLE
ci: python 3.13 support

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -77,7 +77,7 @@ jobs:
       fail-fast: true
       matrix:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
-        python-version: ["3.7", "3.12"]
+        python-version: ["3.7", "3.13"]
         exclude:
           # Latest macos runner does not support older Python versions
           # https://github.com/actions/setup-python/issues/852
@@ -125,7 +125,7 @@ jobs:
         uses: docker/setup-qemu-action@v3
         with:
           platforms: arm64
-      - uses: pypa/cibuildwheel@v2.20.0
+      - uses: pypa/cibuildwheel@v2.21.3
         env:
           CIBW_SKIP: cp36-* pp*-win* pp*-macosx* *_i686
           CIBW_TEST_SKIP: "*-win_arm64"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.6.0
+    rev: v5.0.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
@@ -10,7 +10,7 @@ repos:
       - id: check-yaml
       - id: check-added-large-files
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.6.4
+    rev: v0.7.0
     hooks:
       - id: ruff
         name: ruff check
@@ -24,7 +24,7 @@ repos:
         name: ruff format
         alias: format
   - repo: https://github.com/RobertCraigie/pyright-python
-    rev: v1.1.379
+    rev: v1.1.386
     hooks:
       - id: pyright
-        additional_dependencies: [cython, httpretty, numpy, pytest]
+        additional_dependencies: [cython, httpretty, numpy, pytest, setuptools]

--- a/cryosparc/dataset.py
+++ b/cryosparc/dataset.py
@@ -844,7 +844,7 @@ class Dataset(Streamable, MutableMapping[str, Column], Generic[R]):
         if allocate is None:  # Same as zero
             populate = [(("uid", "<u8"), n.ndarray(0, dtype=n.uint64))]
         elif isinstance(allocate, (int, n.integer)):
-            populate = [(("uid", "<u8"), generate_uids(allocate or 0))]
+            populate = [(("uid", "<u8"), generate_uids(int(allocate)))]
         elif isinstance(allocate, n.ndarray):  # record array
             for field in allocate.dtype.descr:
                 assert field[0], f"Cannot initialize with record array of dtype {allocate.dtype}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dev = [
     "pytest-xdist[psutil]",
     "pytest",
     "ruff",
+    "setuptools",
 ]
 
 build = ["build", "autodocsumm", "cython", "jupyter-book"]


### PR DESCRIPTION
Note that latest pypa/cibuildwheel we were using was already creating Python 3.13 builds for the latest releases.