### PR TITLE
fix: correct stream implementation when dataset is empty

### DIFF
--- a/cryosparc/dataset.py
+++ b/cryosparc/dataset.py
@@ -685,6 +685,9 @@ class Dataset(Streamable, MutableMapping[str, Column], Generic[R]):
         # Calling addrows separately to minimizes column-based
         # allocations, improves performance by ~20%
         dset = cls.allocate(0, descr)
+        if header["length"] == 0:
+            return dset  # no more data to load
+
         data = dset._data
         data.addrows(header["length"])
         loader = Stream(data)
@@ -798,6 +801,9 @@ class Dataset(Streamable, MutableMapping[str, Column], Generic[R]):
         )
         yield u32bytesle(len(header))
         yield header
+
+        if len(self) == 0:
+            return  # empty dataset, don't yield anything
 
         for f in self:
             fielddata: "MemoryView"

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -56,6 +56,27 @@ def small_dset_stream(small_dset):
     return stream
 
 
+@pytest.fixture
+def empty_dset():
+    field3 = "long/fieldwithsuperduperlongcolumnnamethatislongandtestable"
+    return Dataset.allocate(
+        0,
+        fields=[
+            ("field/1", "u8", (2,)),
+            ("field/2", "f4"),
+            (field3, "O"),
+        ],
+    )
+
+
+@pytest.fixture
+def empty_dset_stream(empty_dset):
+    stream = BytesIO()
+    empty_dset.save(stream, format=CSDAT_FORMAT)
+    stream.seek(0)
+    return stream
+
+
 def test_allocate():
     storage = Dataset.allocate(size=2000000, fields=[("field1", "u8"), ("field2", "f4"), ("field3", "O")])
     assert storage is not None
@@ -268,6 +289,11 @@ def test_load_stream_prefixes(small_dset, small_dset_path):
 def test_load_stream_fields(small_dset, small_dset_stream):
     result = Dataset.load(small_dset_stream, fields=["field/2"])
     assert result == small_dset.filter_fields(["field/2"], copy=True)
+
+
+def test_load_empty_stream(empty_dset, empty_dset_stream):
+    result = Dataset.load(empty_dset_stream)
+    assert result == empty_dset
 
 
 def test_pickle_unpickle():


### PR DESCRIPTION
When saving and loading a dataset. Fixes an error that occurs when saving an external output.