### PR TITLE
chore(api-client): drop support for python 3.7

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -79,12 +79,12 @@ jobs:
       fail-fast: true
       matrix:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
-        python-version: ["3.7", "3.13"]
+        python-version: ["3.8", "3.13"]
         exclude:
           # Latest macos runner does not support older Python versions
           # https://github.com/actions/setup-python/issues/852
           - os: macos-latest
-            python-version: "3.7"
+            python-version: "3.8"
     steps:
       - uses: actions/checkout@v4
         with:
@@ -100,10 +100,10 @@ jobs:
           python -m pip install --upgrade pip wheel
           python -m pip install --editable .[dev]
       - name: Downgrade numpy
-        if: ${{ matrix.python-version == '3.7' }}
+        if: ${{ matrix.python-version == '3.8' }}
         run: |
           # test with older numpy version to ensure compatibility
-          python -m pip install numpy==1.15
+          python -m pip install numpy~=1.17.5
       - name: Test with pytest
         run: |
           pytest -v --benchmark-disable -n auto
@@ -129,7 +129,7 @@ jobs:
           platforms: arm64
       - uses: pypa/cibuildwheel@v2.21.3
         env:
-          CIBW_SKIP: cp36-* pp*-win* pp*-macosx* *_i686
+          CIBW_SKIP: cp36-* cp37-* pp*-win* pp*-macosx* *_i686
           CIBW_TEST_SKIP: "*-win_arm64"
           CIBW_ARCHS_LINUX: "x86_64 aarch64"
           CIBW_ARCHS_MACOS: "x86_64 arm64 universal2"

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for full details.
 ### Prerequisites
 
 - Git and Git LFS
-- Python >= 3.7
+- Python >= 3.8
 - Miniconda3
 - C compiler such as GCC or Clang
 

--- a/cryosparc/dataset.py
+++ b/cryosparc/dataset.py
@@ -36,11 +36,13 @@ from typing import (
     Generator,
     Generic,
     List,
+    Literal,
     Mapping,
     MutableMapping,
     Optional,
     Sequence,
     Set,
+    SupportsIndex,
     Tuple,
     Type,
     Union,
@@ -48,7 +50,6 @@ from typing import (
 )
 
 import numpy as n
-from typing import Literal, SupportsIndex
 
 from .column import Column
 from .core import Data, DsetType, Stream

--- a/cryosparc/dataset.py
+++ b/cryosparc/dataset.py
@@ -48,7 +48,7 @@ from typing import (
 )
 
 import numpy as n
-from typing_extensions import Literal, SupportsIndex
+from typing import Literal, SupportsIndex
 
 from .column import Column
 from .core import Data, DsetType, Stream

--- a/cryosparc/dtype.py
+++ b/cryosparc/dtype.py
@@ -3,7 +3,7 @@ Utilities and type definitions for working with dataset fields and column types.
 """
 
 import json
-from typing import TYPE_CHECKING, Dict, List, Optional, Type, Union, TypedDict, Literal, Sequence, Tuple
+from typing import TYPE_CHECKING, Dict, List, Literal, Optional, Sequence, Tuple, Type, TypedDict, Union
 
 import numpy as n
 

--- a/cryosparc/dtype.py
+++ b/cryosparc/dtype.py
@@ -3,10 +3,9 @@ Utilities and type definitions for working with dataset fields and column types.
 """
 
 import json
-from typing import TYPE_CHECKING, Dict, List, Optional, Tuple, Type, Union
+from typing import TYPE_CHECKING, Dict, List, Optional, Type, Union, TypedDict, Literal, Sequence, Tuple
 
 import numpy as n
-from typing_extensions import Literal, Sequence, TypedDict
 
 from .core import Data, DsetType
 

--- a/cryosparc/errors.py
+++ b/cryosparc/errors.py
@@ -2,9 +2,7 @@
 Definitions for various error classes raised by cryosparc-tools functions
 """
 
-from typing import Any, List
-
-from typing_extensions import TypedDict
+from typing import Any, List, TypedDict
 
 from .spec import Datafield, Datatype, SlotSpec
 

--- a/cryosparc/job.py
+++ b/cryosparc/job.py
@@ -10,10 +10,9 @@ from contextlib import contextmanager
 from io import BytesIO
 from pathlib import PurePath, PurePosixPath
 from time import sleep, time
-from typing import IO, TYPE_CHECKING, Any, Dict, Iterable, List, Optional, Pattern, Union, overload
+from typing import IO, TYPE_CHECKING, Any, Dict, Iterable, List, Literal, Optional, Pattern, Union, overload
 
 import numpy as n
-from typing import Literal
 
 from .command import CommandError, make_json_request, make_request
 from .dataset import DEFAULT_FORMAT, Dataset

--- a/cryosparc/job.py
+++ b/cryosparc/job.py
@@ -13,7 +13,7 @@ from time import sleep, time
 from typing import IO, TYPE_CHECKING, Any, Dict, Iterable, List, Optional, Pattern, Union, overload
 
 import numpy as n
-from typing_extensions import Literal
+from typing import Literal
 
 from .command import CommandError, make_json_request, make_request
 from .dataset import DEFAULT_FORMAT, Dataset

--- a/cryosparc/spec.py
+++ b/cryosparc/spec.py
@@ -20,9 +20,7 @@ Examples:
 """
 
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Any, Dict, Generic, List, Optional, Tuple, TypeVar, Union
-
-from typing import Literal, TypedDict
+from typing import Any, Dict, Generic, List, Literal, Optional, Tuple, TypedDict, TypeVar, Union
 
 # Database document
 D = TypeVar("D")

--- a/cryosparc/spec.py
+++ b/cryosparc/spec.py
@@ -22,10 +22,7 @@ Examples:
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Any, Dict, Generic, List, Optional, Tuple, TypeVar, Union
 
-from typing_extensions import Literal, TypedDict
-
-if TYPE_CHECKING:
-    from typing_extensions import Self  # not present in typing-extensions=3.7
+from typing import Literal, TypedDict
 
 # Database document
 D = TypeVar("D")
@@ -964,6 +961,6 @@ class MongoController(ABC, Generic[D]):
         return self._doc
 
     @abstractmethod
-    def refresh(self) -> "Self":
+    def refresh(self):
         # Must be implemented in subclasses
         return self

--- a/cryosparc/star.py
+++ b/cryosparc/star.py
@@ -6,7 +6,7 @@ from pathlib import PurePath
 from typing import IO, TYPE_CHECKING, Any, Callable, Dict, List, Mapping, Optional, Tuple, Type, Union, overload
 
 import numpy as n
-from typing_extensions import Literal
+from typing import Literal
 
 if TYPE_CHECKING:
     from numpy.typing import NDArray  # type: ignore

--- a/cryosparc/star.py
+++ b/cryosparc/star.py
@@ -3,10 +3,23 @@ Helper module for reading and writing relion star files.
 """
 
 from pathlib import PurePath
-from typing import IO, TYPE_CHECKING, Any, Callable, Dict, List, Mapping, Optional, Tuple, Type, Union, overload
+from typing import (
+    IO,
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Dict,
+    List,
+    Literal,
+    Mapping,
+    Optional,
+    Tuple,
+    Type,
+    Union,
+    overload,
+)
 
 import numpy as n
-from typing import Literal
 
 if TYPE_CHECKING:
     from numpy.typing import NDArray  # type: ignore

--- a/cryosparc/stream.py
+++ b/cryosparc/stream.py
@@ -4,7 +4,6 @@ from abc import ABC, abstractmethod
 from pathlib import PurePath
 from typing import (
     IO,
-    TYPE_CHECKING,
     Any,
     AsyncGenerator,
     AsyncIterable,
@@ -14,8 +13,8 @@ from typing import (
     Iterable,
     Iterator,
     Optional,
-    Union,
     Protocol,
+    Union,
 )
 
 from typing_extensions import Self

--- a/cryosparc/stream.py
+++ b/cryosparc/stream.py
@@ -7,18 +7,18 @@ from typing import (
     TYPE_CHECKING,
     Any,
     AsyncGenerator,
+    AsyncIterable,
     AsyncIterator,
     BinaryIO,
     Generator,
+    Iterable,
     Iterator,
     Optional,
     Union,
+    Protocol,
 )
 
-from typing_extensions import Protocol
-
-if TYPE_CHECKING:
-    from typing_extensions import Self  # not present in typing-extensions=3.7
+from typing_extensions import Self
 
 
 class AsyncBinaryIO(Protocol):
@@ -93,7 +93,7 @@ class AsyncBinaryIteratorIO(AsyncBinaryIO):
         out = []
         if n is None or n < 0:
             while True:
-                m = self._read1()
+                m = await self._read1()
                 if not m:
                     break
                 out.append(m)
@@ -153,8 +153,8 @@ class Streamable(ABC):
         return await cls.from_async_stream(AsyncBinaryIteratorIO(iterator))
 
     @abstractmethod
-    def stream(self) -> Generator[bytes, None, None]: ...
+    def stream(self) -> Iterable[bytes]: ...
 
-    async def astream(self):
+    async def astream(self) -> AsyncIterable[bytes]:
         for chunk in self.stream():
             yield chunk

--- a/cryosparc/util.py
+++ b/cryosparc/util.py
@@ -310,10 +310,7 @@ def default_rng(seed=None) -> "n.random.Generator":
     Returns:
         numpy.random.Generator: Random number generator
     """
-    try:
-        return n.random.default_rng(seed)
-    except AttributeError:
-        return n.random.RandomState(seed)  # type: ignore
+    return n.random.default_rng(seed)
 
 
 def random_integers(
@@ -337,11 +334,7 @@ def random_integers(
     Returns:
         NDArray: Numpy array of randomly-generated integers.
     """
-    try:
-        f = rng.integers
-    except AttributeError:
-        f = rng.randint  # type: ignore
-    return f(low=low, high=high, size=size, dtype=dtype)  # type: ignore
+    return rng.integers(low=low, high=high, size=size, dtype=dtype)  # type: ignore
 
 
 def print_table(headings: List[str], rows: List[List[str]]):

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -23,7 +23,7 @@ Source code is [available on GitHub](https://github.com/cryoem-uoft/cryosparc-to
 
 ## Pre-requisites
 
-- [Python ≥ 3.7](https://www.python.org/downloads/)
+- [Python ≥ 3.8](https://www.python.org/downloads/)
 - [CryoSPARC ≥ v4.1](https://cryosparc.com/download)
 
 CryoSPARC installation must be accessible via one of the following methods:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
 license = { file = "LICENSE" }
 dependencies = [
     "numpy >= 1.17, < 3.0",
-    "typing-extensions >= 3.8",
+    "typing-extensions >= 4.0",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "cryosparc-tools"
 version = "4.6.1"
 description = "Toolkit for interfacing with CryoSPARC"
 readme = "README.md"
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 authors = [
     { name = "Structura Biotechnology Inc.", email = "info@structura.bio" },
 ]
@@ -20,7 +20,10 @@ classifiers = [
     "Topic :: Software Development :: Libraries",
 ]
 license = { file = "LICENSE" }
-dependencies = ["numpy >= 1.15, < 3.0", "typing-extensions >= 3.7"]
+dependencies = [
+    "numpy >= 1.17, < 3.0",
+    "typing-extensions >= 3.8",
+]
 
 [project.optional-dependencies]
 dev = [


### PR DESCRIPTION
Reached end-of-life over a year ago and is not supported by upcoming spm dependencies.