### PR TITLE
fix(spm): show response data in API error messages

### DIFF
--- a/cryosparc/errors.py
+++ b/cryosparc/errors.py
@@ -23,7 +23,7 @@ class APIError(ValueError):
     """
 
     code: int
-    data: Any
+    data: Any = None
 
     def __init__(
         self,


### PR DESCRIPTION
Example:
```py
In [3]: api.start_and_migrate(license_id='12312')
...
APIError: *** [API] (PUT http://cryoem0.sbi:61004/start, code 401) received error response
Response data:
{
    "detail": "Invalid License-Id header"
}
```