### PR TITLE
fix(spm): correctly encode enums in query params and headers

### DIFF
--- a/cryosparc/api.py
+++ b/cryosparc/api.py
@@ -10,7 +10,7 @@ import httpx
 
 from . import registry
 from .errors import APIError
-from .json_util import api_default, api_object_hook
+from .json_util import api_default, api_encode, api_object_hook
 from .models.auth import Token
 from .stream import Streamable
 
@@ -74,10 +74,10 @@ class APINamespace:
                 _path = _path.replace("{%s}" % param_name, _uriencode(param))
             elif param_in == "query" and param_name in kwargs:
                 # query param must be in kwargs
-                query_params[param_name] = kwargs.pop(param_name)
+                query_params[param_name] = api_encode(kwargs.pop(param_name))
             elif param_in == "header" and (header_name := param_name.replace("-", "_")) in kwargs:
                 # header must be in kwargs
-                headers[param_name] = kwargs.pop(header_name)
+                headers[param_name] = api_encode(kwargs.pop(header_name))
             elif param_in == "header" and param_name in client_headers:
                 pass  # in default headers, no action required
             elif param_schema["required"]:

--- a/cryosparc/json_util.py
+++ b/cryosparc/json_util.py
@@ -1,10 +1,23 @@
 import base64
 from datetime import datetime
+from enum import Enum
 from pathlib import PurePath
 from typing import Any, Mapping
 
 import numpy as n
 from pydantic import BaseModel
+
+
+def api_encode(obj: Any):
+    """
+    Recursively encode any object for transmission through the API.
+    """
+    if isinstance(obj, dict):
+        return {k: api_encode(v) for k, v in obj}
+    elif isinstance(obj, list):
+        return [api_encode(v) for v in obj]
+    else:
+        return api_default(obj)
 
 
 def api_default(obj: Any) -> Any:
@@ -28,6 +41,8 @@ def api_default(obj: Any) -> Any:
         return binary_to_json(obj)
     elif isinstance(obj, datetime):
         return obj.isoformat()
+    elif isinstance(obj, Enum):
+        return obj.value
     elif isinstance(obj, PurePath):
         return str(obj)
     elif isinstance(obj, BaseModel):


### PR DESCRIPTION
If given an enum list of enums, it should encode their values.