### PR TITLE
feat: find methods multiple projects, workspaces, jobs

### DIFF
--- a/cryosparc/api.pyi
+++ b/cryosparc/api.pyi
@@ -495,9 +495,11 @@ class JobsNamespace(APINamespace):
         created_at: Optional[Tuple[datetime.datetime, datetime.datetime]] = ...,
         updated_at: Optional[Tuple[datetime.datetime, datetime.datetime]] = ...,
         queued_at: Optional[Tuple[datetime.datetime, datetime.datetime]] = ...,
+        started_at: Optional[Tuple[datetime.datetime, datetime.datetime]] = ...,
+        waiting_at: Optional[Tuple[datetime.datetime, datetime.datetime]] = ...,
         completed_at: Optional[Tuple[datetime.datetime, datetime.datetime]] = ...,
         killed_at: Optional[Tuple[datetime.datetime, datetime.datetime]] = ...,
-        started_at: Optional[Tuple[datetime.datetime, datetime.datetime]] = ...,
+        failed_at: Optional[Tuple[datetime.datetime, datetime.datetime]] = ...,
         exported_at: Optional[Tuple[datetime.datetime, datetime.datetime]] = ...,
         deleted: Optional[bool] = False,
     ) -> List[Job]:
@@ -525,9 +527,11 @@ class JobsNamespace(APINamespace):
         created_at: Optional[Tuple[datetime.datetime, datetime.datetime]] = ...,
         updated_at: Optional[Tuple[datetime.datetime, datetime.datetime]] = ...,
         queued_at: Optional[Tuple[datetime.datetime, datetime.datetime]] = ...,
+        started_at: Optional[Tuple[datetime.datetime, datetime.datetime]] = ...,
+        waiting_at: Optional[Tuple[datetime.datetime, datetime.datetime]] = ...,
         completed_at: Optional[Tuple[datetime.datetime, datetime.datetime]] = ...,
         killed_at: Optional[Tuple[datetime.datetime, datetime.datetime]] = ...,
-        started_at: Optional[Tuple[datetime.datetime, datetime.datetime]] = ...,
+        failed_at: Optional[Tuple[datetime.datetime, datetime.datetime]] = ...,
         exported_at: Optional[Tuple[datetime.datetime, datetime.datetime]] = ...,
         deleted: Optional[bool] = False,
     ) -> int:
@@ -746,12 +750,14 @@ class JobsNamespace(APINamespace):
         ...
     def add_external_input(self, project_uid: str, job_uid: str, input_name: str, /, body: InputSpec) -> Job:
         """
-        Add or replace an external job's input.
+        Add or replace an external job's input. This action is available while the
+        job is building, running or waiting for results.
         """
         ...
     def add_external_output(self, project_uid: str, job_uid: str, output_name: str, /, body: OutputSpec) -> Job:
         """
-        Add or replace an external job's output.
+        Add or replace an external job's output. This action is available while the
+        job is building, running or waiting for results.
         """
         ...
     def enqueue(
@@ -821,7 +827,7 @@ class JobsNamespace(APINamespace):
         ...
     def mark_completed(self, project_uid: str, job_uid: str, /) -> Job:
         """
-        Mark a killed or failed job as completed.
+        Mark a killed or failed job, or an active external job, as completed.
         """
         ...
     def mark_failed(self, project_uid: str, job_uid: str, /, *, error: Optional[str] = ...) -> Job:
@@ -882,9 +888,11 @@ class JobsNamespace(APINamespace):
         created_at: Optional[Tuple[datetime.datetime, datetime.datetime]] = ...,
         updated_at: Optional[Tuple[datetime.datetime, datetime.datetime]] = ...,
         queued_at: Optional[Tuple[datetime.datetime, datetime.datetime]] = ...,
+        started_at: Optional[Tuple[datetime.datetime, datetime.datetime]] = ...,
+        waiting_at: Optional[Tuple[datetime.datetime, datetime.datetime]] = ...,
         completed_at: Optional[Tuple[datetime.datetime, datetime.datetime]] = ...,
         killed_at: Optional[Tuple[datetime.datetime, datetime.datetime]] = ...,
-        started_at: Optional[Tuple[datetime.datetime, datetime.datetime]] = ...,
+        failed_at: Optional[Tuple[datetime.datetime, datetime.datetime]] = ...,
         exported_at: Optional[Tuple[datetime.datetime, datetime.datetime]] = ...,
         deleted: Optional[bool] = False,
     ) -> List[Job]:

--- a/cryosparc/controllers/job.py
+++ b/cryosparc/controllers/job.py
@@ -1463,7 +1463,6 @@ class ExternalJobController(JobController):
         if isinstance(error, bool):  # allowed bool in previous version
             warnings.warn("error should be specified as a string", DeprecationWarning, stacklevel=2)
             error = "An error occurred" if error else ""
-        self.model = self.cs.api.jobs.kill(self.project_uid, self.uid)
         if error:
             self.model = self.cs.api.jobs.mark_failed(self.project_uid, self.uid, error=error)
         else:

--- a/cryosparc/controllers/job.py
+++ b/cryosparc/controllers/job.py
@@ -62,7 +62,7 @@ class JobController(Controller[Job]):
     Accessor class to a job in CryoSPARC with ability to load inputs and
     outputs, add to job log, download job files. Should be created with
     :py:meth:`cs.find_job() <cryosparc.tools.CryoSPARC.find_job>` or
-    :py:meth:`project.find_job() <cryosparc.project.ProjectController.find_job>`.
+    :py:meth:`project.find_job() <cryosparc.controllers.project.ProjectController.find_job>`.
 
     Arguments:
         job (tuple[str, str] | Job): either _(Project UID, Job UID)_ tuple or

--- a/cryosparc/controllers/project.py
+++ b/cryosparc/controllers/project.py
@@ -1,13 +1,13 @@
 import warnings
 from pathlib import PurePath, PurePosixPath
-from typing import IO, TYPE_CHECKING, Any, Dict, Iterable, List, Optional, Tuple, Union
+from typing import IO, TYPE_CHECKING, Any, Dict, Iterable, List, Literal, Optional, Tuple, Union
 
 from typing_extensions import Unpack
 
 from ..dataset import DEFAULT_FORMAT, Dataset
 from ..dataset.row import R
 from ..models.project import Project
-from ..search import JobSearch
+from ..search import In, JobSearch
 from ..spec import Datatype, SlotSpec
 from . import Controller, as_output_slot
 from .job import ExternalJobController, JobController
@@ -67,16 +67,16 @@ class ProjectController(Controller[Project]):
         path: str = self.cs.api.projects.get_directory(self.uid)
         return PurePosixPath(path)
 
-    def find_workspaces(self) -> Iterable[WorkspaceController]:
+    def find_workspaces(self, *, order: Literal[1, -1] = 1) -> Iterable[WorkspaceController]:
         """
         Get all workspaces available in the current project.
 
         Returns:
             Iterable[WorkspaceController]: workspace accessor objects
         """
-        return self.cs.find_workspaces(self.uid)
+        return self.cs.find_workspaces(self.uid, order=order)
 
-    def find_workspace(self, workspace_uid) -> WorkspaceController:
+    def find_workspace(self, workspace_uid: str) -> WorkspaceController:
         """
         Get a workspace accessor instance for the workspace in this project
         with the given UID. Fails with an error if workspace does not exist.
@@ -91,7 +91,9 @@ class ProjectController(Controller[Project]):
 
     def find_jobs(
         self,
-        workspace_uid: str | List[str] | None = None,
+        workspace_uid: Optional[In[str]] = None,
+        *,
+        order: Literal[1, -1] = 1,
         **search: Unpack[JobSearch],
     ) -> Iterable[JobController]:
         """
@@ -118,7 +120,7 @@ class ProjectController(Controller[Project]):
         Returns:
             Iterable[JobController]: job accessor objects
         """
-        return self.cs.find_jobs(self.uid, workspace_uid=workspace_uid, **search)
+        return self.cs.find_jobs(self.uid, workspace_uid, order=order, **search)
 
     def find_job(self, job_uid: str) -> JobController:
         """

--- a/cryosparc/controllers/project.py
+++ b/cryosparc/controllers/project.py
@@ -1,10 +1,13 @@
 import warnings
 from pathlib import PurePath, PurePosixPath
-from typing import IO, TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
+from typing import IO, TYPE_CHECKING, Any, Dict, Iterable, List, Optional, Tuple, Union
+
+from typing_extensions import Unpack
 
 from ..dataset import DEFAULT_FORMAT, Dataset
 from ..dataset.row import R
 from ..models.project import Project
+from ..search import JobSearch
 from ..spec import Datatype, SlotSpec
 from . import Controller, as_output_slot
 from .job import ExternalJobController, JobController
@@ -64,6 +67,15 @@ class ProjectController(Controller[Project]):
         path: str = self.cs.api.projects.get_directory(self.uid)
         return PurePosixPath(path)
 
+    def find_workspaces(self) -> Iterable[WorkspaceController]:
+        """
+        Get all workspaces available in the current project.
+
+        Returns:
+            Iterable[WorkspaceController]: workspace accessor objects
+        """
+        return self.cs.find_workspaces(self.uid)
+
     def find_workspace(self, workspace_uid) -> WorkspaceController:
         """
         Get a workspace accessor instance for the workspace in this project
@@ -76,6 +88,26 @@ class ProjectController(Controller[Project]):
             WorkspaceController: workspace accessor object
         """
         return WorkspaceController(self.cs, (self.uid, workspace_uid))
+
+    def find_jobs(
+        self,
+        workspace_uid: str | List[str] | None = None,
+        **search: Unpack[JobSearch],
+    ) -> Iterable[JobController]:
+        """
+        Get jobs available in the current project.
+
+        Args:
+            workspace_uid (str | list[str] | None): Workspace unique ID, e.g.,
+                "W1". If not specified, returns jobs from all workspaces.
+                Defaults to None.
+            **search (JobSearch): Additional search parameters to filter jobs,
+                specified as keyword arguments.
+
+        Returns:
+            Iterable[JobController]: job accessor objects
+        """
+        return self.cs.find_jobs(self.uid, workspace_uid=workspace_uid, **search)
 
     def find_job(self, job_uid: str) -> JobController:
         """

--- a/cryosparc/controllers/project.py
+++ b/cryosparc/controllers/project.py
@@ -95,7 +95,18 @@ class ProjectController(Controller[Project]):
         **search: Unpack[JobSearch],
     ) -> Iterable[JobController]:
         """
-        Get jobs available in the current project.
+        Search jobs available in the current project.
+
+        Example:
+            >>> jobs = project.find_jobs("W3")
+            >>> jobs = project.find_jobs(["W3", "W4"])
+            >>> jobs = project.find_jobs(
+            ...     type="homo_reconstruct",
+            ...     completed_at=(datetime(2025, 3, 1), datetime(2025, 3, 31)),
+            ...     order=-1,
+            ... )
+            >>> for job in jobs:
+            ...     print(job.uid)
 
         Args:
             workspace_uid (str | list[str] | None): Workspace unique ID, e.g.,

--- a/cryosparc/controllers/workspace.py
+++ b/cryosparc/controllers/workspace.py
@@ -20,7 +20,7 @@ class WorkspaceController(Controller[Workspace]):
     Accessor class to a workspace in CryoSPARC with ability create jobs and save
     results. Should be created with`
     :py:meth:`cs.find_workspace() <cryosparc.tools.CryoSPARC.find_workspace>` or
-    :py:meth:`project.find_workspace() <cryosparc.project.ProjectController.find_workspace>`.
+    :py:meth:`project.find_workspace() <cryosparc.controllers.project.ProjectController.find_workspace>`.
 
     Arguments:
         workspace (tuple[str, str] | Workspace): either _(Project UID, Workspace UID)_
@@ -72,6 +72,21 @@ class WorkspaceController(Controller[Workspace]):
             Iterable[JobController]: job accessor objects
         """
         return self.cs.find_jobs(self.project_uid, workspace_uid=self.uid, **search)
+
+    def find_job(self, job_uid: str) -> JobController:
+        """
+        Find a job in the current workspace by its UID.
+
+        Args:
+            job_uid (str): Job UID to find, e.g., "J42"
+
+        Returns:
+            JobController: job accessor object
+        """
+        jobs = self.cs.api.jobs.find(project_uid=[self.project_uid], workspace_uid=[self.uid], uid=[job_uid], limit=1)
+        if len(jobs) == 0:
+            raise ValueError(f"Job {job_uid} not found in workspace {self.project_uid}-{self.uid}")
+        return JobController(self.cs, jobs[0])
 
     def create_job(
         self,

--- a/cryosparc/controllers/workspace.py
+++ b/cryosparc/controllers/workspace.py
@@ -62,7 +62,17 @@ class WorkspaceController(Controller[Workspace]):
 
     def find_jobs(self, **search: Unpack[JobSearch]) -> Iterable[JobController]:
         """
-        Get jobs in the current workspace.
+        Search jobs in the current workspace.
+
+        Example:
+            >>> jobs = workspace.find_jobs()  # all jobs in workspace
+            >>> jobs = workspace.find_jobs(
+            ...     type="homo_reconstruct",
+            ...     completed_at=(datetime(2025, 3, 1), datetime(2025, 3, 31)),
+            ...     order=-1,
+            ... )
+            >>> for job in jobs:
+            ...     print(job.uid)
 
         Args:
             **search (JobSearch): Additional search parameters to filter jobs,

--- a/cryosparc/controllers/workspace.py
+++ b/cryosparc/controllers/workspace.py
@@ -1,5 +1,5 @@
 import warnings
-from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Literal, Optional, Tuple, Union
 
 from typing_extensions import Unpack
 
@@ -60,7 +60,7 @@ class WorkspaceController(Controller[Workspace]):
         self.model = self.cs.api.workspaces.find_one(self.project_uid, self.uid)
         return self
 
-    def find_jobs(self, **search: Unpack[JobSearch]) -> Iterable[JobController]:
+    def find_jobs(self, *, order: Literal[1, -1] = 1, **search: Unpack[JobSearch]) -> Iterable[JobController]:
         """
         Search jobs in the current workspace.
 
@@ -81,7 +81,7 @@ class WorkspaceController(Controller[Workspace]):
         Returns:
             Iterable[JobController]: job accessor objects
         """
-        return self.cs.find_jobs(self.project_uid, workspace_uid=self.uid, **search)
+        return self.cs.find_jobs(self.project_uid, workspace_uid=self.uid, order=order, **search)
 
     def find_job(self, job_uid: str) -> JobController:
         """

--- a/cryosparc/controllers/workspace.py
+++ b/cryosparc/controllers/workspace.py
@@ -1,9 +1,12 @@
 import warnings
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Optional, Tuple, Union
+
+from typing_extensions import Unpack
 
 from ..dataset import Dataset
 from ..dataset.row import R
 from ..models.workspace import Workspace
+from ..search import JobSearch
 from ..spec import Datatype, SlotSpec
 from . import Controller, as_output_slot
 from .job import ExternalJobController, JobController
@@ -56,6 +59,19 @@ class WorkspaceController(Controller[Workspace]):
         """
         self.model = self.cs.api.workspaces.find_one(self.project_uid, self.uid)
         return self
+
+    def find_jobs(self, **search: Unpack[JobSearch]) -> Iterable[JobController]:
+        """
+        Get jobs in the current workspace.
+
+        Args:
+            **search (JobSearch): Additional search parameters to filter jobs,
+                specified as keyword arguments.
+
+        Returns:
+            Iterable[JobController]: job accessor objects
+        """
+        return self.cs.find_jobs(self.project_uid, workspace_uid=self.uid, **search)
 
     def create_job(
         self,

--- a/cryosparc/models/event.py
+++ b/cryosparc/models/event.py
@@ -48,6 +48,12 @@ class ImageEvent(BaseModel):
     imgfiles: List[GridFSAsset] = []
 
 
+class InteractiveGridFSAsset(BaseModel):
+    fileid: str = "000000000000000000000000"
+    filename: str
+    filetype: str
+
+
 class InteractiveImgfile(BaseModel):
     imgfiles: List[GridFSAsset]
     components: List[int] = []
@@ -66,7 +72,7 @@ class InteractiveEvent(BaseModel):
     type: str
     subtype: str = "3dscatter"
     text: str
-    datafile: GridFSAsset
+    datafile: InteractiveGridFSAsset
     preview_imgfiles: List[InteractiveImgfile] = []
     components: List[int] = []
 

--- a/cryosparc/models/job.py
+++ b/cryosparc/models/job.py
@@ -63,7 +63,7 @@ class Job(BaseModel):
     spec: JobSpec
     job_dir: str
     job_dir_size: int = 0
-    job_dir_size_last_updated: Optional[datetime.datetime] = None
+    job_dir_size_last_updated: datetime.datetime
     run_as_user: Optional[str] = None
     title: str = ""
     description: str = ""

--- a/cryosparc/models/session.py
+++ b/cryosparc/models/session.py
@@ -305,7 +305,6 @@ class Session(BaseModel):
     max_timestamps: List[Any] = []
     known_files: List[Any] = []
     rtp_childs: List[RTPChild] = []
-    avg_usage: List[Any] = []
     template_creation_job: Optional[str] = None
     template_creation_project: Optional[str] = None
     template_creation_num_particles_in: int = 0
@@ -365,4 +364,5 @@ class Session(BaseModel):
     ecl: ECLSessionProperties = ECLSessionProperties()
     uid_num: int
     project_uid_num: int
+    session_uid_num: int
     errors: List[SessionBuildError]

--- a/cryosparc/search.py
+++ b/cryosparc/search.py
@@ -6,11 +6,8 @@ from typing_extensions import TypedDict
 from .models.job import JobStatus
 from .models.job_spec import Category
 
-F = TypeVar("F", bound=bool | int | float | str)
-"""Type variable for allowed scalar query types for FastAPI"""
-R = TypeVar("R", bound=int | float | datetime)
-"""Type variable for range types for FastAPI"""
-
+F = TypeVar("F", bool, int, float, str)  # filter value
+R = TypeVar("R", int, float, datetime)  # range
 Eq = F
 In = F | list[F]
 Range = tuple[R, R]

--- a/cryosparc/search.py
+++ b/cryosparc/search.py
@@ -1,0 +1,71 @@
+from datetime import datetime
+from typing import TypeVar
+
+from typing_extensions import TypedDict
+
+from .models.job import JobStatus
+from .models.job_spec import Category
+
+F = TypeVar("F", bound=bool | int | float | str)
+"""Type variable for allowed scalar query types for FastAPI"""
+R = TypeVar("R", bound=int | float | datetime)
+"""Type variable for range types for FastAPI"""
+
+Eq = F
+In = F | list[F]
+Range = tuple[R, R]
+
+
+class JobSearch(TypedDict, total=False):
+    """
+    Type of keyword arguments for ``find_jobs`` methods.
+    """
+
+    type: In[str]
+    """
+    Include jobs with the given type.
+    """
+    status: In[JobStatus]
+    """
+    Include jobs with the given status.
+    """
+    category: In[Category]
+    """
+    Include jobs with the given category.
+    """
+    created_at: Range[datetime]
+    """
+    Include jobs created within the given time range.
+    """
+    updated_at: Range[datetime]
+    """
+    Include jobs updated within the given time range.
+    """
+    queued_at: Range[datetime]
+    """
+    Include jobs queued within the given time range.
+    """
+    started_at: Range[datetime]
+    """
+    Include jobs started within the given time range.
+    """
+    waiting_at: Range[datetime]
+    """
+    Include jobs that started waiting within the given time range.
+    """
+    completed_at: Range[datetime]
+    """
+    Include jobs completed within the given time range.
+    """
+    killed_at: Range[datetime]
+    """
+    Include jobs killed within the given time range.
+    """
+    failed_at: Range[datetime]
+    """
+    Include jobs failed within the given time range.
+    """
+    exported_at: Range[datetime]
+    """
+    Include jobs exported within the given time range.
+    """

--- a/cryosparc/search.py
+++ b/cryosparc/search.py
@@ -1,16 +1,15 @@
 from datetime import datetime
-from typing import TypeVar
+from typing import List, TypeVar
 
 from typing_extensions import TypedDict
 
 from .models.job import JobStatus
 from .models.job_spec import Category
 
-F = TypeVar("F", bool, int, float, str)  # filter value
-R = TypeVar("R", int, float, datetime)  # range
-Eq = F
-In = F | list[F]
-Range = tuple[R, R]
+T = TypeVar("T")
+Eq = T
+In = T | List[T]
+Range = tuple[T, T]
 
 
 class JobSearch(TypedDict, total=False):

--- a/cryosparc/search.py
+++ b/cryosparc/search.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import List, TypeVar
+from typing import List, Tuple, TypeVar, Union
 
 from typing_extensions import TypedDict
 
@@ -8,8 +8,8 @@ from .models.job_spec import Category
 
 T = TypeVar("T")
 Eq = T
-In = T | List[T]
-Range = tuple[T, T]
+In = Union[T, List[T]]
+Range = Tuple[T, T]
 
 
 class JobSearch(TypedDict, total=False):

--- a/cryosparc/tools.py
+++ b/cryosparc/tools.py
@@ -602,8 +602,7 @@ class CryoSPARC:
 
         # Find the most recent workspace or create a new one if the project is empty
         if workspace_uid is None:
-            # TODO: limit find to one workspace
-            workspaces = self.api.workspaces.find(project_uid=[project_uid], order=-1)
+            workspaces = self.api.workspaces.find(project_uid=[project_uid], order=-1, limit=1)
             workspace = workspaces[0] if workspaces else self.api.workspaces.create(project_uid, title=title)
             workspace_uid = workspace.uid
 

--- a/cryosparc/tools.py
+++ b/cryosparc/tools.py
@@ -416,7 +416,18 @@ class CryoSPARC:
         **search: Unpack[JobSearch],
     ) -> Iterable[JobController]:
         """
-        Get available jobs.
+        Search available jobs.
+
+        Example:
+            >>> jobs = cs.find_jobs("P3", "W3")
+            >>> jobs = cs.find_jobs(["P42", "P43"])
+            >>> jobs = cs.find_jobs(
+            ...     type="homo_reconstruct",
+            ...     completed_at=(datetime(2025, 3, 1), datetime(2025, 3, 31)),
+            ...     order=-1,
+            ... )
+            >>> for job in jobs:
+            ...     print(job.uid)
 
         Args:
             project_uid (str | list[str] | None): Project unique ID, e.g., "P3".

--- a/cryosparc/tools.py
+++ b/cryosparc/tools.py
@@ -209,15 +209,15 @@ class CryoSPARC:
 
         if cs_version and VERSION_REGEX.match(cs_version):
             cs_major_minor_version = ".".join(cs_version[1:].split(".")[:2])  # e.g., v4.1.0 -> 4.1
-            tools_prerelease_url = "https://github.com/cryoem-uoft/cryosparc-tools/archive/refs/heads/develop.zip"
             if cs_major_minor_version != tools_major_minor_version:
+                tools_repo_url = "https://github.com/cryoem-uoft/cryosparc-tools.git"
                 warnings.warn(
                     f"CryoSPARC at {self.base_url} with version {cs_version} "
                     f"may not be compatible with current cryosparc-tools version {__version__}.\n\n"
                     "To install a compatible version of cryosparc-tools:\n\n"
                     f"    pip install --force cryosparc-tools~={cs_major_minor_version}.0\n\n"
                     "Or, if running a CryoSPARC pre-release or private beta:\n\n"
-                    f"    pip install --no-cache --force {tools_prerelease_url}\n",
+                    f'    pip install --force "cryosparc-tools @ git+{tools_repo_url}@develop"\n',
                     stacklevel=2,
                 )
 

--- a/cryosparc/tools.py
+++ b/cryosparc/tools.py
@@ -28,9 +28,10 @@ from functools import cached_property
 from hashlib import sha256
 from io import BytesIO, TextIOBase
 from pathlib import PurePath, PurePosixPath
-from typing import IO, TYPE_CHECKING, Any, Container, Dict, Iterable, List, Optional, Tuple, Union, get_args
+from typing import IO, TYPE_CHECKING, Any, Container, Dict, Iterable, List, Literal, Optional, Tuple, Union, get_args
 
 import numpy as n
+from typing_extensions import Unpack
 
 from . import __version__, model_registry, mrc, registry, stream_registry
 from .api import APIClient
@@ -49,6 +50,7 @@ from .models.job_spec import Category, OutputRef, OutputSpec
 from .models.scheduler_lane import SchedulerLane
 from .models.scheduler_target import SchedulerTarget
 from .models.user import User
+from .search import JobSearch
 from .spec import Datatype, JobSection, SlotSpec
 from .stream import BinaryIteratorIO, Stream
 from .util import clear_cached_property, padarray, print_table, trimarray
@@ -334,6 +336,26 @@ class CryoSPARC:
 
         print_table(headings, rows)
 
+    def find_projects(self, *, order: Literal[1, -1] = 1) -> Iterable[ProjectController]:
+        """
+        Get all projects available to the current user.
+
+        Args:
+            order (int, optional): Sort order for projects, 1 for ascending, -1
+                for descending. Defaults to 1.
+
+        Returns:
+            Iterable[ProjectController]: project accessor objects
+        """
+        after = None
+        limit = 10
+        while projects := self.api.projects.find(order=order, after=after, limit=limit):
+            for project in projects:
+                yield ProjectController(self, project)
+            if len(projects) < limit:
+                break
+            after = projects[-1].id
+
     def find_project(self, project_uid: str) -> ProjectController:
         """
         Get a project by its unique ID.
@@ -345,6 +367,31 @@ class CryoSPARC:
             ProjectController: project accessor object
         """
         return ProjectController(self, project_uid)
+
+    def find_workspaces(
+        self, project_uid: str | List[str] | None = None, order: Literal[1, -1] = 1
+    ) -> Iterable[WorkspaceController]:
+        """
+        Get all workspaces available in the given project.
+
+        Args:
+            project_uid (str | list[str] | None): Project unique ID, e.g., "P3".
+                If not specified, returns workspaces from all projects.
+        Returns:
+            Iterable[WorkspaceController]: workspace accessor objects
+        """
+        after = None
+        limit = 100
+        while workspaces := self.api.workspaces.find(
+            project_uid=[project_uid] if isinstance(project_uid, str) else project_uid,
+            after=after,
+            limit=limit,
+        ):
+            for workspace in workspaces:
+                yield WorkspaceController(self, workspace)
+            if len(workspaces) < limit:
+                break
+            after = workspaces[-1].id
 
     def find_workspace(self, project_uid: str, workspace_uid: str) -> WorkspaceController:
         """
@@ -359,6 +406,55 @@ class CryoSPARC:
             WorkspaceController: workspace accessor object
         """
         return WorkspaceController(self, (project_uid, workspace_uid))
+
+    def find_jobs(
+        self,
+        project_uid: str | List[str] | None = None,
+        workspace_uid: str | List[str] | None = None,
+        *,
+        order: Literal[1, -1] = 1,
+        **search: Unpack[JobSearch],
+    ) -> Iterable[JobController]:
+        """
+        Get available jobs.
+
+        Args:
+            project_uid (str | list[str] | None): Project unique ID, e.g., "P3".
+                If not specified, returns jobs from all projects. Defaults to None.
+            workspace_uid (str | list[str] | None): Workspace unique ID, e.g., "W1".
+                If not specified, returns jobs from all workspaces. Defaults to None.
+            **search (JobSearch): Additional search parameters to filter jobs,
+                specified as keyword arguments.
+
+        Returns:
+            Iterable[JobController]: job accessor objects
+        """
+        after = None
+        limit = 100
+        while jobs := self.api.jobs.find(
+            project_uid=[project_uid] if isinstance(project_uid, str) else project_uid,
+            workspace_uid=[workspace_uid] if isinstance(workspace_uid, str) else workspace_uid,
+            type=[type] if isinstance(type := search.get("type"), str) else type,
+            status=[status] if isinstance(status := search.get("status"), str) else status,
+            category=[category] if isinstance(category := search.get("category"), str) else category,
+            created_at=search.get("created_at"),
+            updated_at=search.get("updated_at"),
+            queued_at=search.get("queued_at"),
+            started_at=search.get("started_at"),
+            completed_at=search.get("completed_at"),
+            waiting_at=search.get("waiting_at"),
+            killed_at=search.get("killed_at"),
+            failed_at=search.get("failed_at"),
+            exported_at=search.get("exported_at"),
+            order=order,
+            after=after,
+            limit=limit,
+        ):
+            for job in jobs:
+                yield JobController(self, job)
+            if len(jobs) < limit:
+                break
+            after = jobs[-1].id
 
     def find_job(self, project_uid: str, job_uid: str) -> JobController:
         """

--- a/cryosparc/tools.py
+++ b/cryosparc/tools.py
@@ -50,7 +50,7 @@ from .models.job_spec import Category, OutputRef, OutputSpec
 from .models.scheduler_lane import SchedulerLane
 from .models.scheduler_target import SchedulerTarget
 from .models.user import User
-from .search import JobSearch
+from .search import In, JobSearch
 from .spec import Datatype, JobSection, SlotSpec
 from .stream import BinaryIteratorIO, Stream
 from .util import clear_cached_property, padarray, print_table, trimarray
@@ -369,7 +369,10 @@ class CryoSPARC:
         return ProjectController(self, project_uid)
 
     def find_workspaces(
-        self, project_uid: str | List[str] | None = None, order: Literal[1, -1] = 1
+        self,
+        project_uid: Optional[In[str]] = None,
+        *,
+        order: Literal[1, -1] = 1,
     ) -> Iterable[WorkspaceController]:
         """
         Get all workspaces available in the given project.
@@ -409,8 +412,8 @@ class CryoSPARC:
 
     def find_jobs(
         self,
-        project_uid: str | List[str] | None = None,
-        workspace_uid: str | List[str] | None = None,
+        project_uid: Optional[In[str]] = None,
+        workspace_uid: Optional[In[str]] = None,
         *,
         order: Literal[1, -1] = 1,
         **search: Unpack[JobSearch],

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -320,6 +320,7 @@ def mock_new_job(mock_user, mock_project):
             resource_spec=ResourceSpec(),
         ),
         build_errors=[],
+        job_dir_size_last_updated=datetime.now(timezone.utc),
     )
 
 

--- a/tests/controllers/test_job.py
+++ b/tests/controllers/test_job.py
@@ -1,4 +1,5 @@
 import sys
+from datetime import datetime, timezone
 from unittest import mock
 
 import pytest
@@ -120,6 +121,7 @@ def mock_external_job(mock_user, mock_project):
             resource_spec=ResourceSpec(),
         ),
         build_errors=[],
+        job_dir_size_last_updated=datetime.now(timezone.utc),
     )
 
 


### PR DESCRIPTION
- New `find_projects`, `find_workspaces` and `find_jobs` methods for relevant controllers. `find_jobs` includes filtering arguments.
- Avoid sending now-unnecessary kill command