### PR TITLE
feat: update functionality for job.log with name argument

### DIFF
--- a/cryosparc/api.pyi
+++ b/cryosparc/api.pyi
@@ -1858,6 +1858,31 @@ class JobsAPI(APINamespace):
 
         """
         ...
+    def update_event_log(
+        self,
+        project_uid: str,
+        job_uid: str,
+        event_id: str = "000000000000000000000000",
+        /,
+        text: Optional[str] = None,
+        *,
+        type: Optional[Literal["text", "warning", "error"]] = None,
+    ) -> TextEvent:
+        """
+        Update a text event log entry for a job.
+
+        Args:
+            project_uid (str): Project UID, e.g., "P3"
+            job_uid (str): Job UID, e.g., "J3"
+            event_id (str, optional): Defaults to '000000000000000000000000'
+            text (str, optional): Defaults to None
+            type (Literal['text', 'warning', 'error'], optional): Defaults to None
+
+        Returns:
+            TextEvent: Successful Response
+
+        """
+        ...
     def recalculate_size(self, project_uid: str, job_uid: str, /) -> Job:
         """
         Recalculates the size of a given job's directory.

--- a/cryosparc/controllers/job.py
+++ b/cryosparc/controllers/job.py
@@ -57,6 +57,11 @@ GROUP_NAME_PATTERN = r"^[A-Za-z][0-9A-Za-z_]*$"
 Input and output result groups may only contain, letters, numbers and underscores.
 """
 
+LogLevel = Literal["text", "warning", "error"]
+"""
+Severity level for job event logs.
+"""
+
 
 class JobController(Controller[Job]):
     """
@@ -536,19 +541,27 @@ class JobController(Controller[Job]):
         """
         return self.cs.api.jobs.load_output(self.project_uid, self.uid, name, slots=slots, version=version)
 
-    def log(self, text: str, *, level: Literal["text", "warning", "error"] = "text", name: Optional[str] = None):
+    @overload
+    def log(self, text: str, *, level: LogLevel = ...) -> str: ...
+    @overload
+    def log(self, text: str, *, level: LogLevel = ..., name: str) -> str: ...
+    @overload
+    def log(self, text: str, *, level: LogLevel = ..., id: str) -> str: ...
+    def log(self, text: str, *, level: LogLevel = "text", name: Optional[str] = None, id: Optional[str] = None) -> str:
         """
-        Append to a job's event log. Update an existing log by providing a name.
+        Append to a job's event log. Update an existing log by providing a name
+        or ID.
 
         Args:
             text (str): Text to log
             level (str, optional): Log level ("text", "warning" or "error").
                 Defaults to "text".
-            name (str, optional): Event name or ID. If called multiple times
-                with the same name, updates that event instead of creating a new
-                one. If name is not initially provided, can pass returned ID as
-                name. Named events are reset when logging a checkpoint.
-                Defaults to None.
+            name (str, optional): Event name. If called multiple times with the
+                same name, updates that event instead of creating a new one.
+                Named events are reset when logging a checkpoint. Cannot be
+                provided with id. Defaults to None.
+            id (str, optional): Update a previously-created event log by its ID.
+                Cannot be provided with name. Defaults to None.
 
         Example:
 
@@ -569,15 +582,20 @@ class JobController(Controller[Job]):
             >>> job.log("Finished processing", name=event_id)
 
         Returns:
-            str: Created log event name or ID
+            str: Created log event ID
         """
+        existing_id = id
         if name and name in self._events:
-            event_id = self._events[name]
-            event = self.cs.api.jobs.update_event_log(self.project_uid, self.uid, event_id, text, type=level)
+            existing_id = self._events[name]
+
+        if existing_id:
+            event = self.cs.api.jobs.update_event_log(self.project_uid, self.uid, existing_id, text, type=level)
         else:
             event = self.cs.api.jobs.add_event_log(self.project_uid, self.uid, text, type=level)
-            self._events[name or event.id] = event.id
-        return name or event.id
+
+        if name:
+            self._events[name] = event.id
+        return event.id
 
     def log_checkpoint(self, meta: dict = {}):
         """

--- a/cryosparc/controllers/job.py
+++ b/cryosparc/controllers/job.py
@@ -570,9 +570,7 @@ class JobController(Controller[Job]):
             event = self.cs.api.jobs.update_event_log(self.project_uid, self.uid, event_id, text, type=level)
         else:
             event = self.cs.api.jobs.add_event_log(self.project_uid, self.uid, text, type=level)
-            self._events[event.id] = event.id
-            if name:
-                self._events[name] = event.id
+            self._events[name or event.id] = event.id
         return name or event.id
 
     def log_checkpoint(self, meta: dict = {}):

--- a/cryosparc/controllers/job.py
+++ b/cryosparc/controllers/job.py
@@ -108,7 +108,7 @@ class JobController(Controller[Job]):
     Project unique ID, e.g., "P3"
     """
 
-    _events: dict[str, str]
+    _events: Dict[str, str]
     """
     Named event logs
 

--- a/cryosparc/controllers/job.py
+++ b/cryosparc/controllers/job.py
@@ -534,7 +534,7 @@ class JobController(Controller[Job]):
         """
         return self.cs.api.jobs.load_output(self.project_uid, self.uid, name, slots=slots, version=version)
 
-    def log(self, text: str, *, level: Literal["text", "warning", "error"] = "text", name: str | None = None):
+    def log(self, text: str, *, level: Literal["text", "warning", "error"] = "text", name: Optional[str] = None):
         """
         Append to a job's event log. Update an existing log by providing a name.
 

--- a/cryosparc/controllers/job.py
+++ b/cryosparc/controllers/job.py
@@ -544,10 +544,11 @@ class JobController(Controller[Job]):
             text (str): Text to log
             level (str, optional): Log level ("text", "warning" or "error").
                 Defaults to "text".
-            name (str, optional): Event name or ID. If an event with the same
-                name or ID already exists, updates it instead of creating a new
-                one. Named events are reset when logging a checkpoint. Defaults
-                to None.
+            name (str, optional): Event name or ID. If called multiple times
+                with the same name, updates that event instead of creating a new
+                one. If name is not initially provided, can pass returned ID as
+                name. Named events are reset when logging a checkpoint.
+                Defaults to None.
 
         Example:
 
@@ -561,6 +562,11 @@ class JobController(Controller[Job]):
             ...     sleep(1)
             ...
             >>> job.log("Done!")
+
+            Update an existing log event by ID.
+            >>> event_id = job.log("Starting job processing...")
+            >>> # do some processing...
+            >>> job.log("Finished processing", name=event_id)
 
         Returns:
             str: Created log event name or ID

--- a/cryosparc/controllers/job.py
+++ b/cryosparc/controllers/job.py
@@ -110,7 +110,9 @@ class JobController(Controller[Job]):
 
     _events: Dict[str, str]
     """
-    Named event logs
+    Named event logs. Key can be user-provided name in log() method, or ID if
+    name not provided. If both name and ID are used, can have two keys with
+    the same value.
 
     :meta private:
     """
@@ -568,7 +570,9 @@ class JobController(Controller[Job]):
             event = self.cs.api.jobs.update_event_log(self.project_uid, self.uid, event_id, text, type=level)
         else:
             event = self.cs.api.jobs.add_event_log(self.project_uid, self.uid, text, type=level)
-            self._events[name or event.id] = event.id
+            self._events[event.id] = event.id
+            if name:
+                self._events[name] = event.id
         return name or event.id
 
     def log_checkpoint(self, meta: dict = {}):

--- a/cryosparc/controllers/job.py
+++ b/cryosparc/controllers/job.py
@@ -579,7 +579,7 @@ class JobController(Controller[Job]):
             Update an existing log event by ID.
             >>> event_id = job.log("Starting job processing...")
             >>> # do some processing...
-            >>> job.log("Finished processing", name=event_id)
+            >>> job.log("Finished processing", id=event_id)
 
         Returns:
             str: Created log event ID

--- a/tests/controllers/test_job.py
+++ b/tests/controllers/test_job.py
@@ -80,7 +80,10 @@ def test_job_subprocess_io(job: JobController):
         [sys.executable, "-c", 'import sys; print("hello"); print("error", file=sys.stderr); print("world")']
     )
 
-    assert len(mock_log_endpoint.mock_calls) == 7  # includes some prelude/divider calls
+    # The corrected log method now stores event IDs which causes additional .id property access calls
+    # Filter to only the actual add_event_log calls, not the .id property accesses
+    actual_calls = [call for call in mock_log_endpoint.mock_calls if not str(call).endswith(".id.__hash__()")]
+    assert len(actual_calls) == 7  # includes some prelude/divider calls
     mock_log_endpoint.assert_has_calls(
         [
             mock.call(job.project_uid, job.uid, "hello", type="text"),
@@ -185,3 +188,101 @@ def test_external_job_output(mock_external_job_with_saved_output: ExternalJobCon
 def test_invalid_external_job_output(external_job):
     with pytest.raises(ValueError, match="Invalid output name"):
         external_job.add_output("particle", name="particles/1", slots=["blob", "ctf"])
+
+
+@pytest.fixture
+def mock_log_event():
+    return mock.MagicMock(id="event_123")
+
+
+@pytest.fixture
+def mock_checkpoint_event():
+    return mock.MagicMock(id="checkpoint_456")
+
+
+def test_log_without_name(job: JobController, mock_log_event):
+    assert isinstance(mock_add_endpoint := APIClient.jobs.add_event_log, mock.Mock)
+    mock_add_endpoint.return_value = mock_log_event
+
+    result = job.log("Test message without name")
+
+    mock_add_endpoint.assert_called_once_with(job.project_uid, job.uid, "Test message without name", type="text")
+    assert result == mock_log_event.id
+
+
+def test_log_with_name_create_and_update(job: JobController, mock_log_event):
+    assert isinstance(mock_add_endpoint := APIClient.jobs.add_event_log, mock.Mock)
+    assert isinstance(mock_update_endpoint := APIClient.jobs.update_event_log, mock.Mock)
+    mock_add_endpoint.return_value = mock_log_event
+    mock_update_endpoint.return_value = mock_log_event
+
+    # First call with name - should create
+    result1 = job.log("First message", name="progress")
+
+    mock_add_endpoint.assert_called_once_with(job.project_uid, job.uid, "First message", type="text")
+    assert result1 == "progress"
+
+    # Second call with same name - should update
+    result2 = job.log("Updated message", level="warning", name="progress")
+
+    mock_update_endpoint.assert_called_once_with(
+        job.project_uid, job.uid, mock_log_event.id, "Updated message", type="warning"
+    )
+    assert result2 == "progress"
+
+
+def test_log_with_returned_event_id_as_name(job: JobController, mock_log_event):
+    assert isinstance(mock_add_endpoint := APIClient.jobs.add_event_log, mock.Mock)
+    assert isinstance(mock_update_endpoint := APIClient.jobs.update_event_log, mock.Mock)
+    mock_add_endpoint.return_value = mock_log_event
+    mock_update_endpoint.return_value = mock_log_event
+
+    # First call without name - returns event ID
+    event_id = job.log("Initial message")
+    assert event_id == mock_log_event.id
+
+    # Second call using the returned event ID as name - should update
+    result = job.log("Updated with event ID", name=event_id)
+
+    mock_update_endpoint.assert_called_once_with(
+        job.project_uid, job.uid, mock_log_event.id, "Updated with event ID", type="text"
+    )
+    assert result == event_id
+
+
+def test_log_after_checkpoint_creates_new(job: JobController, mock_log_event, mock_checkpoint_event):
+    """Test case 5: log after with a previously-used name immediately after a log_checkpoint (should create)"""
+    assert isinstance(mock_add_endpoint := APIClient.jobs.add_event_log, mock.Mock)
+    assert isinstance(mock_update_endpoint := APIClient.jobs.update_event_log, mock.Mock)
+    assert isinstance(mock_checkpoint_endpoint := APIClient.jobs.add_checkpoint, mock.Mock)
+
+    mock_add_endpoint.return_value = mock_log_event
+    mock_update_endpoint.return_value = mock_log_event
+    mock_checkpoint_endpoint.return_value = mock_checkpoint_event
+
+    job.log("Before checkpoint", name="status")
+
+    # Create checkpoint - should clear _events
+    checkpoint_id = job.log_checkpoint()
+    mock_checkpoint_endpoint.assert_called_once_with(job.project_uid, job.uid, {})
+    assert checkpoint_id == mock_checkpoint_event.id
+
+    # Log again with same name - should create new since _events was cleared
+    mock_add_endpoint.reset_mock()  # Reset to track the second call
+    result = job.log("After checkpoint", name="status")
+    mock_add_endpoint.assert_called_with(job.project_uid, job.uid, "After checkpoint", type="text")
+    assert result == "status"
+
+
+def test_log_with_different_levels(job: JobController, mock_log_event):
+    """Test logging with different log levels"""
+    assert isinstance(mock_add_endpoint := APIClient.jobs.add_event_log, mock.Mock)
+    mock_add_endpoint.return_value = mock_log_event
+
+    # Test warning level
+    job.log("Warning message", level="warning")
+    mock_add_endpoint.assert_called_with(job.project_uid, job.uid, "Warning message", type="warning")
+
+    # Test error level
+    job.log("Error message", level="error")
+    mock_add_endpoint.assert_called_with(job.project_uid, job.uid, "Error message", type="error")


### PR DESCRIPTION
Update an existing log by providing a name for it. Can use the ID of a previously-logged event as a name. Named events are reset when adding a checkpoint.

For example, show a live progress bar in the job log.
```py
for pct in range(1, 10):
    # example log: "Progress: [#####-----] 50%"
    job.log(f"Progress: [{'#' * pct}{'-' * (10 - pct)}] {pct * 10}%", name="progress")
    sleep(1)
```