### PR TITLE
fix: increase max numpy header size

### DIFF
--- a/cryosparc/dataset/__init__.py
+++ b/cryosparc/dataset/__init__.py
@@ -105,7 +105,7 @@ FORMAT_MAGIC_PREFIXES = {
 MAGIC_PREFIX_FORMATS = {v: k for k, v in FORMAT_MAGIC_PREFIXES.items()}  # inverse dict
 
 _NUMPY_MAJOR_MINOR_VERSION = tuple(map(int, n.__version__.split(".")[:2]))  # e.g., "1.23.4" -> (1, 23)
-_NUMPY_LOAD_KWARGS: dict[str, Any] = {"max_header_size": 1024**3} if _NUMPY_MAJOR_MINOR_VERSION >= (1, 24) else {}
+_NUMPY_LOAD_KWARGS: Dict[str, Any] = {"max_header_size": 1024**3} if _NUMPY_MAJOR_MINOR_VERSION >= (1, 24) else {}
 """Numpy >= 1.24 load function require max_header_size, which is 10000 by default and too small for some datasets."""
 
 


### PR DESCRIPTION
When loading dataset. Prevents load failure for some datasets with large headers.

Performance impact of increasing to 1G header size seems negligible.

**Before**
```
------------------------------------------------------------------------------------------ benchmark: 4 tests ------------------------------------------------------------------------------------------
Name (time in ms)                  Min                   Max                  Mean             StdDev                Median                IQR            Outliers     OPS            Rounds  Iterations
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_load_fields              402.8112 (1.0)        417.7213 (1.0)        411.5838 (1.0)       5.7533 (1.0)        411.3083 (1.0)       7.6192 (1.0)           2;0  2.4296 (1.0)           5           1
test_load_prefixes            456.8055 (1.13)       477.4800 (1.14)       463.1189 (1.13)      8.6912 (1.51)       458.9032 (1.12)     11.0676 (1.45)          1;0  2.1593 (0.89)          5           1
test_load_prefixes_fields     724.2547 (1.80)       762.4599 (1.83)       735.4097 (1.79)     16.1326 (2.80)       727.5969 (1.77)     19.6801 (2.58)          1;0  1.3598 (0.56)          5           1
test_load                     975.6950 (2.42)     1,081.3214 (2.59)     1,019.8017 (2.48)     45.0052 (7.82)     1,012.2993 (2.46)     76.9011 (10.09)         1;0  0.9806 (0.40)          5           1
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```

**After**
```
------------------------------------------------------------------------------------------ benchmark: 4 tests ------------------------------------------------------------------------------------------
Name (time in ms)                  Min                   Max                  Mean             StdDev                Median                IQR            Outliers     OPS            Rounds  Iterations
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_load_fields              399.0714 (1.0)        412.0033 (1.0)        402.3032 (1.0)       5.4844 (1.32)       400.1449 (1.0)       4.6679 (1.0)           1;1  2.4857 (1.0)           5           1
test_load_prefixes            451.3765 (1.13)       468.8956 (1.14)       458.0699 (1.14)      7.0038 (1.69)       458.1964 (1.15)      9.6970 (2.08)          1;0  2.1831 (0.88)          5           1
test_load_prefixes_fields     744.7618 (1.87)       755.7792 (1.83)       750.8266 (1.87)      4.1418 (1.0)        751.1518 (1.88)      5.5390 (1.19)          2;0  1.3319 (0.54)          5           1
test_load                     928.3221 (2.33)     1,106.3936 (2.69)     1,015.9634 (2.53)     65.8999 (15.91)    1,006.2870 (2.51)     84.1364 (18.02)         2;0  0.9843 (0.40)          5           1
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```