### PR TITLE
feat!: querying a non-existant field raises KeyError

### DIFF
--- a/cryosparc/dataset/__init__.py
+++ b/cryosparc/dataset/__init__.py
@@ -1474,6 +1474,8 @@ class Dataset(Streamable, MutableMapping[str, Column], Generic[R]):
             NDArray[bool]: Query mask, may be used with the ``mask()`` method.
         """
         query_fields = set(self.fields()).intersection(query.keys())
+        if len(missing_fields := set(query.keys()) - query_fields) != 0:
+            raise KeyError(f"Fields not in dataset: {', '.join(missing_fields)}")
         mask = n.ones(len(self), dtype=bool)
         for field in query_fields:
             mask &= n.isin(self[field], query[field])

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -154,6 +154,12 @@ def test_invalid_key_assignment():
         storage["gain_ref_blob/path"] = ["Hello", "World!"]
 
 
+def test_invalid_key_query():
+    storage = Dataset.allocate()
+    with pytest.raises(KeyError):
+        storage.query({"invalid_field": "Hello world"})
+
+
 def test_non_existent_key_assignment():
     storage = Dataset.allocate(size=3)
     with pytest.raises(AssertionError):

--- a/tests/test_dataset_bench.py
+++ b/tests/test_dataset_bench.py
@@ -343,12 +343,6 @@ def test_subset_simple_query_empty(benchmark, dset: Dataset):
     assert len(new_dset) == len(dset)
 
 
-def test_subset_simple_query_fake_field(benchmark, dset: Dataset):
-    new_dset = benchmark(dset.query, {"fake_field": 42})
-    assert new_dset == dset
-    assert len(new_dset) == len(dset)
-
-
 def test_subset_simple_query_nomatch(benchmark, big_dset, dset: Dataset):
     new_dset = benchmark(dset.query, {"uid": [42]})
     assert len(dset) == len(big_dset), "Should not mutate original dset"


### PR DESCRIPTION
Breaking change.

Right now, querying a dataset with a non-existent field returns the entire dataset. I find this counterintuitive and have been bitten by it several times. For example, trying to filter particles with a typo of `location/mcrograph_uid` instead of `location/micrograph_uid` results in *all* particles in the dataset returning. Python (e.g., `dict["key"]` vs. `dict.get("key")`), popular dataframe packages (e.g., pandas), and numpy (structured arrays) all raise exceptions of some flavor when attempting to access data with a key that's not in the object.

This commit changes the behavior of `Dataset.query_mask()` to raise a KeyError when attempting to query non-existent fields, and lists the missing fields in the exception message. I also removed the test for the old behavior and added a test for the new behavior.