### PR TITLE
chore: bump pypa/cibuildwheel for deployment

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -124,7 +124,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: true
-      - uses: pypa/cibuildwheel@v3.2.1
+      - uses: pypa/cibuildwheel@v3.3.0
         env:
           CIBW_ARCHS_MACOS: ${{ runner.arch == 'ARM64' && 'auto universal2' || 'auto' }}
         with:


### PR DESCRIPTION
v3.2.1 -> v3.3.0