### PR TITLE
feat: enforce slot loading in load_output()

### DIFF
--- a/cryosparc/controllers/job.py
+++ b/cryosparc/controllers/job.py
@@ -549,6 +549,11 @@ class JobController(Controller[Job]):
         Returns:
             Dataset: Loaded dataset
         """
+        if isinstance(slots, list):
+            slot_set = set(x.split("/")[0] for x in slots)
+            if slot_set != set(slots):
+                warnings.warn(f"only whole slots can be loaded, not fields. Loading {slot_set}", stacklevel=2)
+                slots = sorted(list(slot_set))
         return self.cs.api.jobs.load_output(self.project_uid, self.uid, name, slots=slots, version=version)
 
     @overload

--- a/tests/controllers/test_job.py
+++ b/tests/controllers/test_job.py
@@ -74,6 +74,19 @@ def test_load_output_some_slots(job: JobController, t20s_particles, t20s_particl
     )
 
 
+def test_load_output_fields(job: JobController, t20s_particles, t20s_particles_passthrough):
+    assert isinstance(mock_load_output_endpoint := APIClient.jobs.load_output, mock.Mock)
+    mock_load_output_endpoint.return_value = t20s_particles.innerjoin(t20s_particles_passthrough)
+    fields_and_slots = ["location", "blob", "ctf/scale", "ctf/df_angle_rad"]
+    slots = ["blob", "ctf", "location"]
+    with pytest.warns(UserWarning, match="only whole slots"):
+        particles = job.load_output("particles_class_0", slots=fields_and_slots)
+    assert set(particles.prefixes()) == set(slots)
+    mock_load_output_endpoint.assert_called_once_with(
+        job.project_uid, job.uid, "particles_class_0", slots=slots, version="F"
+    )
+
+
 def test_job_subprocess_io(job: JobController):
     assert isinstance(mock_log_endpoint := APIClient.jobs.add_event_log, mock.Mock)
 


### PR DESCRIPTION
If a user provides a field name instead of a slot/prefix, convert to the associated slot with a warning. This resolves a common mistake users make of providing e.g.,` "ctf/df1_A"` instead of `"ctf"`.