### PR TITLE
fix: handle HTTPS/base_url construction in CryoSPARC init

### DIFF
--- a/cryosparc/tools.py
+++ b/cryosparc/tools.py
@@ -162,11 +162,17 @@ class CryoSPARC:
         if host or base_port:
             if base_url:
                 raise TypeError("Cannot specify host or base_port when base_url is specified")
-            host = host or "localhost"
-            port = int(base_port or 39000)
-            self.base_url = f"http://{host}:{port}"
+            host = (host or "localhost").strip().rstrip("/")
+
+            # If user passed full URL in host, respect it and ignore base_port
+            if host.startswith("http://") or host.startswith("https://"):
+                self.base_url = host
+            else:
+                port = int(base_port or 39000)
+                scheme = "https" if port == 443 else "http"
+                self.base_url = f"{scheme}://{host}:{port}"
         elif base_url:
-            self.base_url = base_url
+            self.base_url = base_url.strip().rstrip("/")
         else:
             raise TypeError("Must specify either base_url or host + base_port")
 


### PR DESCRIPTION
## Summary
Fix URL construction in `CryoSPARC.__init__` when connecting via `host`/`base_port` for HTTPS deployments.

This affects deployments behind HTTPS reverse proxies or TLS terminators, where the Python API tool must connect via  `https://` on port `443`.
Previously, the `host` path always forced `http://{host}:{port}`, which could produce malformed URLs such as:
- `http://https://...` and/or use the wrong scheme for TLS endpoints on port 443.

## Changes
- If `host` already includes a scheme (`http://` or `https://`), use it directly.
- Otherwise, infer `https` when `base_port == 443`, else `http`.
- Normalize trailing slashes for `base_url`.

